### PR TITLE
Map descs and empty sides

### DIFF
--- a/macros/SXCmacros.cfg
+++ b/macros/SXCmacros.cfg
@@ -426,6 +426,7 @@
 # 1 allowed
 # X equal special
 
+# deprecated, replaced by SXC_ARMORY_LIMITS_AND_EMPTY_SIDES
 #define SXC_ARMORY_LIMIT SIDE
   {VARIABLE sxc_side {SIDE}}
   [fire_event]
@@ -1375,6 +1376,7 @@
   [/if]
 #enddef
 
+# deprecated, replaced by SXC_ARMORY_LIMITS_AND_EMPTY_SIDES
 #define SXC_NO_GOLD_FOR_NOBODY
   {VARIABLE i 1}
   [while]
@@ -1397,6 +1399,49 @@
             side=$i
           [/gold]
         [/then]
+      [/if]
+      {VARIABLE_OP i add 1}
+    [/do]
+  [/while]
+  {CLEAR_VARIABLE i}
+  {CLEAR_VARIABLE gold_trans}
+#enddef
+
+# This combines the old
+#    {SXC_ARMORY_LIMIT 1}
+#    {SXC_ARMORY_LIMIT 2}
+#    {SXC_ARMORY_LIMIT 3}
+#    {SXC_ARMORY_LIMIT 4}
+#    {SXC_ARMORY_LIMIT 5}
+#    {SXC_NO_GOLD_FOR_NOBODY}
+# sequence, and only runs the sxc_armory_limits routine for sides that have a leader.
+#define SXC_ARMORY_LIMITS_AND_EMPTY_SIDES
+  {VARIABLE i 1}
+  [while]
+    {SXC_CMP i less_than_equal_to 5}
+    [do]
+      [store_gold]
+        side=$i
+        variable=gold_trans
+      [/store_gold]
+      [if]
+          [have_unit]
+            side=$i
+            canrecruit=yes
+          [/have_unit]
+        [then]
+          {VARIABLE sxc_side $i}
+          [fire_event]
+            name=sxc_armory_limits
+          [/fire_event]
+          {CLEAR_VARIABLE sxc_side}
+        [/then]
+        [else]
+          [gold]
+            amount=-$gold_trans
+            side=$i
+          [/gold]
+        [/else]
       [/if]
       {VARIABLE_OP i add 1}
     [/do]

--- a/macros/SXCmacros.cfg
+++ b/macros/SXCmacros.cfg
@@ -7,9 +7,20 @@
 # !!! Also set your editing software to not insert <TAB> characters automatically instead of set number of spaces !!!
 #
 
+# Macro for descriptions that need an empty line, so that the description itself is easier to read
+#define SXC_MAP_NOTES_NEW_PARAGRAPH
+  "
+
+"#enddef
+
+#define SXC_MAP_DEFAULT_DESCRIPTION
+  _ "In SurvivalXtreme, you have to kill all enemy leaders or survive until the turn limit expires. You play only with your leader but you can enhance it during the game. You get gold, extra moves and an extra attack for every enemy you kill. Use default map settings otherwise you will lose immediately. Have fun!"#enddef
+
+#define SXC_MAP_NOTES_REQUIRES_AGELESS
+  _ "This map requires Ageless Era to be installed on every player's computer" + {SXC_MAP_NOTES_NEW_PARAGRAPH}#enddef
+
 # This is macro for easier settings for normal SX maps
 #define SXC_DEFAULT_MAP_SETTINGS TURNS CONDITION STORY_BACKGROUND STORY
-  description="You have to try to kill all leaders or survive until the turn limit expires. You play only with your leader but you can enhance it during the game. You get gold, extra moves and attack for every enemy you kill. Use default map settings otherwise you will lose immediately. Best use the SXC or SurvivalXtreme Era. Have fun!"
   experience_modifier=130%
   turns=-1
   victory_when_enemies_defeated=no

--- a/scen_def/SXC_Advanced.cfg
+++ b/scen_def/SXC_Advanced.cfg
@@ -3,7 +3,7 @@
   id=SXC_Advanced_{SXC_VERSION}
   name="SXC Advanced {SXC_VERSION}"
   map_data="{~add-ons/SXCollection/maps/SXC_Advanced.map}"
-  description= _ "You have to try to kill all leaders or survive until the turn limit expires. You play only with your leader but you can enhance it during the game. You get gold, extra moves and attack for every enemy you kill. Use default map settings otherwise you will lose immediately. Best use the SXC or SurivalXtreme Era. Have fun!"
+  description={SXC_MAP_DEFAULT_DESCRIPTION}
   {SXC_DEFAULT_MAP_SETTINGS 100 "win" "data/core/images/portraits/undead/death-knight.png" "<span color='#BCB088' weight='bold' face='roman'>Earn gold from kills and chests and use it to improve your unit in shops. Special items found on the map can also improve your unit as long as you have them in inventory. All enemy leaders can respawn at certain turns except last boss. Try to survive until end of turns or kill all enemy leaders...</span>"}
 
 #   {SXC_TEST_PLAYER_SIDE_2 1 800 (color=red)}

--- a/scen_def/SXC_Advanced.cfg
+++ b/scen_def/SXC_Advanced.cfg
@@ -43,12 +43,7 @@
 
   [event]
     name=start
-    {SXC_ARMORY_LIMIT 1}
-    {SXC_ARMORY_LIMIT 2}
-    {SXC_ARMORY_LIMIT 3}
-    {SXC_ARMORY_LIMIT 4}
-    {SXC_ARMORY_LIMIT 5}
-    {SXC_NO_GOLD_FOR_NOBODY}
+    {SXC_ARMORY_LIMITS_AND_EMPTY_SIDES}
 
     {SXC_BEFORE_SHOPS}
     {SXC_SHOP_2 3 11 "scenery/tent-shop-weapons.png"}

--- a/scen_def/SXC_Adventure.cfg
+++ b/scen_def/SXC_Adventure.cfg
@@ -3,7 +3,7 @@
   id=SXC_Adventure_{SXC_VERSION}
   name="SXC Adventure {SXC_VERSION}"
   map_data="{~add-ons/SXCollection/maps/SXC_Adventure.map}"
-  description= _ "You have to try to kill all leaders or survive until the turn limit expires. You play only with your leader but you can enhance it during the game. You get gold, extra moves and attack for every enemy you kill. Use default map settings otherwise you will lose immediately. Best use the SXC or SurivalXtreme Era. Have fun!"
+  description={SXC_MAP_DEFAULT_DESCRIPTION}
   {SXC_DEFAULT_MAP_SETTINGS 150 "win" "data/core/images/portraits/humans/necromancer.png" "<span color='#BCB088' size='small' weight='bold' face='roman'>Earn gold from kills and chests and use it to improve your unit in shops. Special items found on the map can also improve your unit as long as you have them in inventory. All enemy leaders can respawn at certain turns except last boss. Try to survive until end of turns or kill all enemy leaders...</span>"}
 
 #   {SXC_TEST_PLAYER_SIDE_2 1 800 (color=red)}

--- a/scen_def/SXC_Adventure.cfg
+++ b/scen_def/SXC_Adventure.cfg
@@ -45,12 +45,7 @@
 
   [event]
     name=start
-    {SXC_ARMORY_LIMIT 1}
-    {SXC_ARMORY_LIMIT 2}
-    {SXC_ARMORY_LIMIT 3}
-    {SXC_ARMORY_LIMIT 4}
-    {SXC_ARMORY_LIMIT 5}
-    {SXC_NO_GOLD_FOR_NOBODY}
+    {SXC_ARMORY_LIMITS_AND_EMPTY_SIDES}
 
     {SXC_BEFORE_SHOPS}
     {SXC_SHOP_2 5 45 "terrain/village/tropical-forest.png"}

--- a/scen_def/SXC_BraveHeart.cfg
+++ b/scen_def/SXC_BraveHeart.cfg
@@ -44,12 +44,7 @@ You have to try to kill all leaders or survive until the turn limit expires. You
 
   [event]
     name=start
-    {SXC_ARMORY_LIMIT 1}
-    {SXC_ARMORY_LIMIT 2}
-    {SXC_ARMORY_LIMIT 3}
-    {SXC_ARMORY_LIMIT 4}
-    {SXC_ARMORY_LIMIT 5}
-    {SXC_NO_GOLD_FOR_NOBODY}
+    {SXC_ARMORY_LIMITS_AND_EMPTY_SIDES}
 
     {SXC_BEFORE_SHOPS}
     {SXC_SHOP_2 3 19 "scenery/tent-shop-weapons.png"}

--- a/scen_def/SXC_BraveHeart.cfg
+++ b/scen_def/SXC_BraveHeart.cfg
@@ -3,8 +3,7 @@
   id=SXC_BraveHeart_{SXC_VERSION}
   name="SXC Brave Heart {SXC_VERSION}"
   map_data="{~add-ons/SXCollection/maps/SXC_BraveHeart.map}"
-  description= _ "      *** Mod by riklaunim, further changes by -stf- ***
-You have to try to kill all leaders or survive until the turn limit expires. You play only with your leader but you can enhance it during the game. You get gold, extra moves and attack for every enemy you kill. Use default map settings otherwise you will lose immediately. Best use the SXC or SurivalXtreme Era. Have fun!"
+  description={SXC_MAP_DEFAULT_DESCRIPTION} + {SXC_MAP_NOTES_NEW_PARAGRAPH} + _ "*** Mod by riklaunim, further changes by -stf- ***"
   {SXC_DEFAULT_MAP_SETTINGS 100 "win" "data/core/images/portraits/undead/lich.png" "<span color='#BCB088' size='small' weight='bold' face='roman'>Earn gold from kills and chests and use it to improve your unit in shops. Special items found on the map can also improve your unit as long as you have them in inventory. All enemy leaders can respawn at certain turns. Try to survive until end of turns or kill all enemy leaders...</span>"}
 
 #   {SXC_TEST_PLAYER_SIDE_2 1 800 (color=red)}

--- a/scen_def/SXC_Chambers.cfg
+++ b/scen_def/SXC_Chambers.cfg
@@ -3,7 +3,7 @@
   id=SXC_Chambers_{SXC_VERSION}
   name= _ "SXC Chambers {SXC_VERSION}"
   map_data="{~add-ons/SXCollection/maps/SXC_Chambers.map}"
-  description= _ "You have to try to kill all leaders until the turn limit expires. You play with only your leader but you can enhance it during the game. You get gold, extra moves and attacks for every enemy you kill. Use default map settings otherwise you will lose immediately. Best use the SXC or SurivalXtreme Era. Have fun!"
+  description={SXC_MAP_DEFAULT_DESCRIPTION}
   {SXC_DEFAULT_MAP_SETTINGS 95 "lose" "data/core/images/portraits/undead/death-knight.png" "<span color='#BCB088' weight='bold' face='roman'>Earn gold from kills and chests and use it to improve your unit in shops. Special items found on the map can also improve your unit as long as you have them in inventory. Try to survive until end of turns or kill all enemy leaders...</span>"}
 
 #   {SXC_TEST_PLAYER_SIDE_2 1 800 (color=red)}

--- a/scen_def/SXC_Chambers.cfg
+++ b/scen_def/SXC_Chambers.cfg
@@ -43,12 +43,7 @@
 
   [event]
     name=start
-    {SXC_ARMORY_LIMIT 1}
-    {SXC_ARMORY_LIMIT 2}
-    {SXC_ARMORY_LIMIT 3}
-    {SXC_ARMORY_LIMIT 4}
-    {SXC_ARMORY_LIMIT 5}
-    {SXC_NO_GOLD_FOR_NOBODY}
+    {SXC_ARMORY_LIMITS_AND_EMPTY_SIDES}
 
     {SXC_BEFORE_SHOPS}
     {SXC_SHOP_2 3 24 "terrain/village/human-city2.png~FL()"}

--- a/scen_def/SXC_Classic.cfg
+++ b/scen_def/SXC_Classic.cfg
@@ -46,12 +46,7 @@
 
   [event]
     name=start
-    {SXC_ARMORY_LIMIT 1}
-    {SXC_ARMORY_LIMIT 2}
-    {SXC_ARMORY_LIMIT 3}
-    {SXC_ARMORY_LIMIT 4}
-    {SXC_ARMORY_LIMIT 5}
-    {SXC_NO_GOLD_FOR_NOBODY}
+    {SXC_ARMORY_LIMITS_AND_EMPTY_SIDES}
 
     {SXC_BEFORE_SHOPS}
     {SXC_SHOP_2 6 18 "terrain/village/tropical-forest.png"}

--- a/scen_def/SXC_Classic.cfg
+++ b/scen_def/SXC_Classic.cfg
@@ -3,7 +3,7 @@
   id=SXC_Classic_{SXC_VERSION}
   name="SXC Classic {SXC_VERSION}"
   map_data="{~add-ons/SXCollection/maps/SXC_Classic.map}"
-  description=_ "You have to try to survive as long as possible. You start with only one unit, but you can enhance it during the game. You get gold for every unit you kill. The turn limit means the turn until you must survive. Use the SXC era or SurvivalXtreme Era. Have fun!"
+  description={SXC_MAP_DEFAULT_DESCRIPTION}
   {SXC_DEFAULT_MAP_SETTINGS 100 "win" "data/core/images/portraits/undead/lich.png" "<span color='#BCB088' size='small' weight='bold' face='roman'>You have to try to survive as long as possible. You start with only one unit, but you can enhance it during the game. You get gold for every unit you kill. The turn limit means the turn until you must survive. Use the SXC era or SurvivalXtreme Era. Have fun!</span>"}
 
 #   {SXC_TEST_PLAYER_SIDE_2 1 800 (color=red)}

--- a/scen_def/SXC_Curve.cfg
+++ b/scen_def/SXC_Curve.cfg
@@ -7,8 +7,7 @@
   id=SXC_Curve_{SXC_VERSION}
   name="SXC Curve {SXC_VERSION}"
   map_data="{~add-ons/SXCollection/maps/SXC_Curve.map}"
-  description= _ "Mod by Big_Bob
-You have to try to survive as long as possible. You start with only one unit, but you can enhance it during the game. You get gold for every unit you kill. The turn limit means the turn you must survive until. Use the SXC or SurvivalXtreme Era. Have fun."
+  description={SXC_MAP_DEFAULT_DESCRIPTION} + {SXC_MAP_NOTES_NEW_PARAGRAPH} + _ "Mod by Big_Bob"
   {SXC_DEFAULT_MAP_SETTINGS 100 "win" "data/core/images/portraits/undead/death-knight.png" "<span color='#BCB088' size='small' weight='bold' face='roman'>Survive until the turns run out or defeat all enemy leaders to win. There are shops where you can enhance your unit for gold. For any unit you kill you get gold and gain 4 MP back, what allows you to attack as long as possible. There will also appear some exceptionally strong bosses later, and the creeps will become stronger over time. But now, have fun!</span>"}
 
 #   {SXC_TEST_PLAYER_SIDE_2 1 800 (color=red)}

--- a/scen_def/SXC_Curve.cfg
+++ b/scen_def/SXC_Curve.cfg
@@ -51,12 +51,7 @@ You have to try to survive as long as possible. You start with only one unit, bu
 
   [event]
     name=start
-    {SXC_ARMORY_LIMIT 1}
-    {SXC_ARMORY_LIMIT 2}
-    {SXC_ARMORY_LIMIT 3}
-    {SXC_ARMORY_LIMIT 4}
-    {SXC_ARMORY_LIMIT 5}
-    {SXC_NO_GOLD_FOR_NOBODY}
+    {SXC_ARMORY_LIMITS_AND_EMPTY_SIDES}
 
     {SXC_BEFORE_SHOPS}
     {SXC_SHOP_2 6 18 "terrain/village/human-city.png"}

--- a/scen_def/SXC_IsarsCrossfire.cfg
+++ b/scen_def/SXC_IsarsCrossfire.cfg
@@ -3,7 +3,7 @@
   id=SXC_IsarsCrossfire_{SXC_VERSION}
   name="SXC Isar's Crossfire {SXC_VERSION}"
   map_data="{~add-ons/SXCollection/maps/SXC_IsarsCrossfire.map}"
-  description=_ "You have to defeat all enemy leaders. You start with only one unit, but you can enhance it during the game. You get gold for every unit you kill. The turn limit means the turn until you must survive. Use the SXC era or SurvivalXtreme Era. Have fun!"
+  description={SXC_MAP_DEFAULT_DESCRIPTION}
   {SXC_DEFAULT_MAP_SETTINGS 95 "win" "data/core/images/portraits/undead/death-knight.png" "<span color='#BCB088' size='small' weight='bold' face='roman'>You have to defeat all leaders or survive until turns run out. You start with only one unit, but you can enhance it during the game. You get gold for every unit you kill. There will also appear some exceptionally strong bosses later and the creeps will become stronger over time. But now, have fun!</span>"}
 
 #   {SXC_TEST_PLAYER_SIDE_2 1 800 (color=red)}

--- a/scen_def/SXC_IsarsCrossfire.cfg
+++ b/scen_def/SXC_IsarsCrossfire.cfg
@@ -48,12 +48,7 @@
 
   [event]
     name=start
-    {SXC_ARMORY_LIMIT 1}
-    {SXC_ARMORY_LIMIT 2}
-    {SXC_ARMORY_LIMIT 3}
-    {SXC_ARMORY_LIMIT 4}
-    {SXC_ARMORY_LIMIT 5}
-    {SXC_NO_GOLD_FOR_NOBODY}
+    {SXC_ARMORY_LIMITS_AND_EMPTY_SIDES}
 
     {SXC_BEFORE_SHOPS}
     {SXC_SHOP_2 11 11 "terrain/village/drake5.png"}

--- a/scen_def/SXC_Maze.cfg
+++ b/scen_def/SXC_Maze.cfg
@@ -43,12 +43,7 @@
 
   [event]
     name=start
-    {SXC_ARMORY_LIMIT 1}
-    {SXC_ARMORY_LIMIT 2}
-    {SXC_ARMORY_LIMIT 3}
-    {SXC_ARMORY_LIMIT 4}
-    {SXC_ARMORY_LIMIT 5}
-    {SXC_NO_GOLD_FOR_NOBODY}
+    {SXC_ARMORY_LIMITS_AND_EMPTY_SIDES}
 
     {SXC_BEFORE_SHOPS}
     {SXC_SHOP_2 21 3 "terrain/village/tropical-forest.png"}

--- a/scen_def/SXC_Maze.cfg
+++ b/scen_def/SXC_Maze.cfg
@@ -3,7 +3,7 @@
   id=SXC_Maze_{SXC_VERSION}
   name="SXC Maze {SXC_VERSION}"
   map_data="{~add-ons/SXCollection/maps/SXC_Maze.map}"
-  description= _ "You have to try to kill all leaders or survive until the turn limit expires. You play only with your leader but you can enhance it during the game. You get gold, extra moves and attack for every enemy you kill. Use default map settings otherwise you will lose immediately. Best use the SXC or SurivalXtreme Era. Have fun!"
+  description={SXC_MAP_DEFAULT_DESCRIPTION}
   {SXC_DEFAULT_MAP_SETTINGS 100 "win" "data/core/images/portraits/undead/death-knight.png" "<span color='#BCB088' weight='bold' face='roman'>Earn gold from kills and chests and use it to improve your unit in shops. Special items found on the map can also improve your unit as long as you have them in inventory. All enemy leaders can respawn at certain turns except last boss. Try to survive until end of turns or kill all enemy leaders...</span>"}
 
 #   {SXC_TEST_PLAYER_SIDE_2 1 800 (color=red)}

--- a/scen_def/SXC_Rumble.cfg
+++ b/scen_def/SXC_Rumble.cfg
@@ -45,12 +45,7 @@
 
   [event]
     name=start
-    {SXC_ARMORY_LIMIT 1}
-    {SXC_ARMORY_LIMIT 2}
-    {SXC_ARMORY_LIMIT 3}
-    {SXC_ARMORY_LIMIT 4}
-    {SXC_ARMORY_LIMIT 5}
-    {SXC_NO_GOLD_FOR_NOBODY}
+    {SXC_ARMORY_LIMITS_AND_EMPTY_SIDES}
 
     {SXC_BEFORE_SHOPS}
     {SXC_SHOP_2 5 12 "terrain/village/human-city.png"}

--- a/scen_def/SXC_Rumble.cfg
+++ b/scen_def/SXC_Rumble.cfg
@@ -3,7 +3,7 @@
   id=SXC_Rumble_{SXC_VERSION}
   name="SXC Rumble {SXC_VERSION}"
   map_data="{~add-ons/SXCollection/maps/SXC_Rumble.map}"
-  description= _ "You have to try to kill all leaders until the turn limit expires. You play only with your leader but you can enhance it during the game. You get gold, extra moves and attack for every enemy you kill. Use default map settings otherwise you will lose immediately. Best use the SXC or SurivalXtreme Era. Have fun!"
+  description={SXC_MAP_DEFAULT_DESCRIPTION}
   {SXC_DEFAULT_MAP_SETTINGS 150 "lose" "data/core/images/portraits/elves/sylph.png" "<span color='#BCB088' weight='bold' face='roman'>Earn gold from kills and chests and use it to improve your unit in shops. Special items found on the map can also improve your unit as long as you have them in inventory. All enemy leaders can respawn at certain turns except last boss. Try to survive until end of turns or kill all enemy leaders...</span>"}
 
 #   {SXC_TEST_PLAYER_SIDE_2 1 800 (color=red)}

--- a/scen_def/SXC_Stronghold.cfg
+++ b/scen_def/SXC_Stronghold.cfg
@@ -3,7 +3,7 @@
   id=SXC_Stronghold_{SXC_VERSION}
   name="SXC Stronghold {SXC_VERSION}"
   map_data="{~add-ons/SXCollection/maps/SXC_Stronghold.map}"
-  description=_ "You have to defeat all enemy leaders. You start with only one unit, but you can enhance it during the game. You get gold for every unit you kill. The turn limit means the turn until you must win. Use the SXC era or SurvivalXtreme Era. Have fun!"
+  description={SXC_MAP_DEFAULT_DESCRIPTION}
   {SXC_DEFAULT_MAP_SETTINGS 100 "lose" "data/core/images/units/monsters/yeti.png" "<span color='#BCB088' size='small' weight='bold' face='roman'>You have to defeat all enemy Leaders. You start with only one unit, but you can enhance it during the game. You get gold for every unit you kill. A turn limit means you have to win until it ends. Have fun!</span>"}
 
 #   {SXC_TEST_PLAYER_SIDE_2 1 800 (color=red)}

--- a/scen_def/SXC_Stronghold.cfg
+++ b/scen_def/SXC_Stronghold.cfg
@@ -48,12 +48,7 @@
 
   [event]
     name=start
-    {SXC_ARMORY_LIMIT 1}
-    {SXC_ARMORY_LIMIT 2}
-    {SXC_ARMORY_LIMIT 3}
-    {SXC_ARMORY_LIMIT 4}
-    {SXC_ARMORY_LIMIT 5}
-    {SXC_NO_GOLD_FOR_NOBODY}
+    {SXC_ARMORY_LIMITS_AND_EMPTY_SIDES}
 
     {SXC_BEFORE_SHOPS}
     {SXC_SHOP_2 15 15 "terrain/village/human-city.png"}

--- a/scen_def/SXC_System.cfg
+++ b/scen_def/SXC_System.cfg
@@ -3,7 +3,7 @@
   id=SXC_System_{SXC_VERSION}
   name="SXC System {SXC_VERSION}"
   map_data="{~add-ons/SXCollection/maps/SXC_System.map}"
-  description= _ "You have to try to kill all leaders or survive until the turn limit expires. You play only with your leader but you can enhance it during the game. You get gold, extra moves and attack for every enemy you kill. Use default map settings otherwise you will lose immediately. Best use the SXC or SurivalXtreme Era. Have fun!"
+  description={SXC_MAP_DEFAULT_DESCRIPTION}
   {SXC_DEFAULT_MAP_SETTINGS 150 "win" "data/core/images/portraits/elves/sylph.png" "<span color='#BCB088' size='small' weight='bold' face='roman'>Earn gold from kills and chests and use it to improve your unit in shops. Special items found on the map can also improve your unit as long as you have them in inventory. All enemy leaders can respawn at certain turns. There will also come some strong bosses later and expect traps around valuable items or gold. Try to survive until end of turns or kill all enemy leaders... But now, have fun!</span>"}
 
 #   {SXC_TEST_PLAYER_SIDE_2 1 800 (color=red)}

--- a/scen_def/SXC_System.cfg
+++ b/scen_def/SXC_System.cfg
@@ -47,12 +47,7 @@
 
   [event]
     name=start
-    {SXC_ARMORY_LIMIT 1}
-    {SXC_ARMORY_LIMIT 2}
-    {SXC_ARMORY_LIMIT 3}
-    {SXC_ARMORY_LIMIT 4}
-    {SXC_ARMORY_LIMIT 5}
-    {SXC_NO_GOLD_FOR_NOBODY}
+    {SXC_ARMORY_LIMITS_AND_EMPTY_SIDES}
 
     {SXC_BEFORE_SHOPS}
     {SXC_SHOP_2 35 42 "terrain/village/human-city.png"}

--- a/scen_gol/SXC_Attack.cfg
+++ b/scen_gol/SXC_Attack.cfg
@@ -45,12 +45,7 @@ Your Quest is to rid the lands of your enemies! For glory? For fame? For vengean
 
   [event]
     name=start
-    {SXC_ARMORY_LIMIT 1}
-    {SXC_ARMORY_LIMIT 2}
-    {SXC_ARMORY_LIMIT 3}
-    {SXC_ARMORY_LIMIT 4}
-    {SXC_ARMORY_LIMIT 5}
-    {SXC_NO_GOLD_FOR_NOBODY}
+    {SXC_ARMORY_LIMITS_AND_EMPTY_SIDES}
 
     {SXC_BEFORE_SHOPS}
     {SXC_SHOP_2 3 25 "scenery/tent-shop-weapons.png"}

--- a/scen_gol/SXC_Attack.cfg
+++ b/scen_gol/SXC_Attack.cfg
@@ -3,7 +3,7 @@
   id=SXC_Attack_{SXC_VERSION}
   name="SXC Attack {SXC_VERSION}"
   map_data="{~add-ons/SXCollection/maps/SXC_Attack.map}"
-  description= _ "You have to try to kill all leaders or survive until the turn limit expires. You play only with your leader but you can enhance it during the game. You get gold, extra moves and attack for every enemy you kill. Use default map settings otherwise you will lose immediately. Best use the SXC or SurivalXtreme Era. Have fun!"
+  description={SXC_MAP_DEFAULT_DESCRIPTION}
   {SXC_DEFAULT_MAP_SETTINGS 90 "win" "data/core/images/portraits/drakes/clasher.png" "<span color='#BCB088' weight='bold' face='roman'>Map by Golbeeze
 Survive as long as possible while trying to kill the enemy leaders. You receive money for every kill which you want to spend in the shop.
 Your Quest is to rid the lands of your enemies! For glory? For fame? For vengeance? All three? Enjoy!</span>"}

--- a/scen_gol/SXC_Channels.cfg
+++ b/scen_gol/SXC_Channels.cfg
@@ -46,12 +46,7 @@ Your foes have built a vast stronghold across strange lands. They are constantly
 
   [event]
     name=start
-    {SXC_ARMORY_LIMIT 1}
-    {SXC_ARMORY_LIMIT 2}
-    {SXC_ARMORY_LIMIT 3}
-    {SXC_ARMORY_LIMIT 4}
-    {SXC_ARMORY_LIMIT 5}
-    {SXC_NO_GOLD_FOR_NOBODY}
+    {SXC_ARMORY_LIMITS_AND_EMPTY_SIDES}
 
     {SXC_BEFORE_SHOPS}
     {SXC_SHOP_2 16 39 "terrain/village/human-city.png"}

--- a/scen_gol/SXC_Channels.cfg
+++ b/scen_gol/SXC_Channels.cfg
@@ -3,8 +3,7 @@
   id=SXC_Channels_{SXC_VERSION}
   name="SXC Channels {SXC_VERSION}"
   map_data="{~add-ons/SXCollection/maps/SXC_Channels.map}"
-  description= _ "This map requires Ageless Era!
-  You have to try to kill all leaders or survive until the turn limit expires. You play only with your leader but you can enhance it during the game. You get gold, extra moves and attack for every enemy you kill. Use default map settings otherwise you will lose immediately. Best use the SXC or SurivalXtreme Era."
+  description={SXC_MAP_NOTES_REQUIRES_AGELESS} + {SXC_MAP_DEFAULT_DESCRIPTION}
   {SXC_DEFAULT_MAP_SETTINGS 90 "win" "~add-ons/Ageless_Era/images/units/fiends/lucifer.png" "<span color='#BCB088' weight='bold' face='roman'>Map by Golbeeze
 Survive as long as possible while trying to kill the enemy leaders. You receive money for every kill which you want to spend in the shop.
 Your foes have built a vast stronghold across strange lands. They are constantly gathering power to themselves and must be stopped quickly, before it is too late. Enjoy!</span>"}

--- a/scen_gol/SXC_Extend.cfg
+++ b/scen_gol/SXC_Extend.cfg
@@ -45,12 +45,7 @@ More foolish warriors appear before you, challenging your power. Show them no me
 
   [event]
     name=start
-    {SXC_ARMORY_LIMIT 1}
-    {SXC_ARMORY_LIMIT 2}
-    {SXC_ARMORY_LIMIT 3}
-    {SXC_ARMORY_LIMIT 4}
-    {SXC_ARMORY_LIMIT 5}
-    {SXC_NO_GOLD_FOR_NOBODY}
+    {SXC_ARMORY_LIMITS_AND_EMPTY_SIDES}
 
     {SXC_BEFORE_SHOPS}
     {SXC_SHOP_2 52 22 "terrain/village/human-city3.png"}

--- a/scen_gol/SXC_Extend.cfg
+++ b/scen_gol/SXC_Extend.cfg
@@ -3,8 +3,7 @@
   id=SXC_Extend_{SXC_VERSION}
   name="SXC Extend {SXC_VERSION}"
   map_data="{~add-ons/SXCollection/maps/SXC_Extend.map}"
-  description= _ "This map requires Ageless Era!
-Survive as long as possible while trying to kill the enemy leaders. You start with only one unit, but you can enhance it during the game. Use default settings or you will lose immediately. Best use the SXC or SurivalXtreme Era."
+  description={SXC_MAP_NOTES_REQUIRES_AGELESS} + {SXC_MAP_DEFAULT_DESCRIPTION}
   {SXC_DEFAULT_MAP_SETTINGS 95 "win" "data/core/images/portraits/humans/necromancer.png" "<span color='#BCB088' weight='bold' face='roman'>Map by Golbeeze
 More foolish warriors appear before you, challenging your power. Show them no mercy! Enjoy!</span>"}
 

--- a/scen_gol/SXC_Figure.cfg
+++ b/scen_gol/SXC_Figure.cfg
@@ -3,8 +3,7 @@
   id=SXC_Figure_{SXC_VERSION}
   name="SXC Figure {SXC_VERSION}"
   map_data="{~add-ons/SXCollection/maps/SXC_Figure.map}"
-  description= _ "This map requires Ageless Era!
-Survive and kill all enemy leaders. You receive money for every kill which you want in the shop to improve your unit. Best use the SXC or SurivalXtreme Era."
+  description={SXC_MAP_NOTES_REQUIRES_AGELESS} + {SXC_MAP_DEFAULT_DESCRIPTION}
   {SXC_DEFAULT_MAP_SETTINGS 90 "lose" "~add-ons/Ageless_Era/images/units/fiends/lucifer.png" "<span color='#BCB088' weight='bold' face='roman'>Map by Golbeeze
 Kill the enemy leaders before turns expire. You receive money for every kill which you want to spend in the shop.
 Several factions have claimed this land as their own. However, you and your allies have also come to claim it! Who will prevail in this mighty battle? Enjoy!</span>"}

--- a/scen_gol/SXC_Figure.cfg
+++ b/scen_gol/SXC_Figure.cfg
@@ -46,12 +46,7 @@ Several factions have claimed this land as their own. However, you and your alli
 
   [event]
     name=start
-    {SXC_ARMORY_LIMIT 1}
-    {SXC_ARMORY_LIMIT 2}
-    {SXC_ARMORY_LIMIT 3}
-    {SXC_ARMORY_LIMIT 4}
-    {SXC_ARMORY_LIMIT 5}
-    {SXC_NO_GOLD_FOR_NOBODY}
+    {SXC_ARMORY_LIMITS_AND_EMPTY_SIDES}
 
     {SXC_BEFORE_SHOPS}
     {SXC_SHOP_2 2 1 "terrain/village/human-city.png"}

--- a/scen_gol/SXC_Mythos.cfg
+++ b/scen_gol/SXC_Mythos.cfg
@@ -45,12 +45,7 @@ A strange land lies ahead full of mysterious beasts waiting to be conquered! Enj
 
   [event]
     name=start
-    {SXC_ARMORY_LIMIT 1}
-    {SXC_ARMORY_LIMIT 2}
-    {SXC_ARMORY_LIMIT 3}
-    {SXC_ARMORY_LIMIT 4}
-    {SXC_ARMORY_LIMIT 5}
-    {SXC_NO_GOLD_FOR_NOBODY}
+    {SXC_ARMORY_LIMITS_AND_EMPTY_SIDES}
 
     {SXC_BEFORE_SHOPS}
     {SXC_SHOP_2 14 38 "terrain/village/human-city3.png"}

--- a/scen_gol/SXC_Mythos.cfg
+++ b/scen_gol/SXC_Mythos.cfg
@@ -3,8 +3,7 @@
   id=SXC_Mythos_{SXC_VERSION}
   name="SXC Mythos {SXC_VERSION}"
   map_data="{~add-ons/SXCollection/maps/SXC_Mythos.map}"
-  description= _ "This map requires Ageless Era!
-Survive and kill all enemy leaders. You start with only one unit, but you can enhance it during the game. Use default settings or you will lose immediately. Best use the SXC or SurivalXtreme Era."
+  description={SXC_MAP_NOTES_REQUIRES_AGELESS} + {SXC_MAP_DEFAULT_DESCRIPTION}
   {SXC_DEFAULT_MAP_SETTINGS 95 "lose" "data/core/images/portraits/humans/necromancer.png" "<span color='#BCB088' weight='bold' face='roman'>Map by Golbeeze
 A strange land lies ahead full of mysterious beasts waiting to be conquered! Enjoy!</span>"}
 

--- a/scen_gol/SXC_Ramblin.cfg
+++ b/scen_gol/SXC_Ramblin.cfg
@@ -3,7 +3,7 @@
   id=SXC_Ramblin_{SXC_VERSION}
   name="SXC Ramblin {SXC_VERSION}"
   map_data="{~add-ons/SXCollection/maps/SXC_Ramblin.map}"
-  description= _ "You have to try to kill all leaders or survive until the turn limit expires. You play only with your leader but you can enhance it during the game. You get gold, extra moves and attack for every enemy you kill. Use default map settings otherwise you will lose immediately. Best use the SXC or SurivalXtreme Era. Have fun!"
+  description={SXC_MAP_DEFAULT_DESCRIPTION}
   {SXC_DEFAULT_MAP_SETTINGS 90 "win" "data/core/images/portraits/orcs/assassin.png" "<span color='#BCB088' weight='bold' face='roman'>Map by Golbeeze
 Survive as long as possible while trying to kill the enemy leaders. You receive money for every kill which you want to spend in the shop.
 Travelling across the country is a tough task for adventurers. Is your band up to the challenge? Enjoy!</span>"}

--- a/scen_gol/SXC_Ramblin.cfg
+++ b/scen_gol/SXC_Ramblin.cfg
@@ -45,12 +45,7 @@ Travelling across the country is a tough task for adventurers. Is your band up t
 
   [event]
     name=start
-    {SXC_ARMORY_LIMIT 1}
-    {SXC_ARMORY_LIMIT 2}
-    {SXC_ARMORY_LIMIT 3}
-    {SXC_ARMORY_LIMIT 4}
-    {SXC_ARMORY_LIMIT 5}
-    {SXC_NO_GOLD_FOR_NOBODY}
+    {SXC_ARMORY_LIMITS_AND_EMPTY_SIDES}
 
     {SXC_BEFORE_SHOPS}
     {SXC_SHOP_2 34 3 "terrain/village/human3.png"}

--- a/scen_gol/SXC_Rush.cfg
+++ b/scen_gol/SXC_Rush.cfg
@@ -3,8 +3,7 @@
   id=SXC_Rush_{SXC_VERSION}
   name="SXC Rush {SXC_VERSION}"
   map_data="{~add-ons/SXCollection/maps/SXC_Rush.map}"
-  description= _ "This map requires Ageless Era!
-Survive as long as possible while trying to kill the enemy leaders. You receive money for every kill which you want in the shop to improve your unit. Best use the SXC or SurivalXtreme Era."
+  description={SXC_MAP_NOTES_REQUIRES_AGELESS} + {SXC_MAP_DEFAULT_DESCRIPTION}
   {SXC_DEFAULT_MAP_SETTINGS 90 "win" "~add-ons/Ageless_Era/images/units/fiends/lucifer.png" "<span color='#BCB088' weight='bold' face='roman'>Map by Golbeeze
 Survive as long as possible while trying to kill the enemy leaders. You receive money for every kill which you want to spend in the shop.
 Having infiltrated the enemy lands, you once again seek the annihilation of your foes. These crafty villains have spread thoroughly and may strike from anywhere at anytime! Only the strongest warriors shall prevail against these odds. Enjoy!</span>"}

--- a/scen_gol/SXC_Rush.cfg
+++ b/scen_gol/SXC_Rush.cfg
@@ -46,12 +46,7 @@ Having infiltrated the enemy lands, you once again seek the annihilation of your
 
   [event]
     name=start
-    {SXC_ARMORY_LIMIT 1}
-    {SXC_ARMORY_LIMIT 2}
-    {SXC_ARMORY_LIMIT 3}
-    {SXC_ARMORY_LIMIT 4}
-    {SXC_ARMORY_LIMIT 5}
-    {SXC_NO_GOLD_FOR_NOBODY}
+    {SXC_ARMORY_LIMITS_AND_EMPTY_SIDES}
 
     {SXC_BEFORE_SHOPS}
     {SXC_SHOP_2 20 20 "terrain/village/human-city.png"}

--- a/scen_gol/SXC_Simple.cfg
+++ b/scen_gol/SXC_Simple.cfg
@@ -47,12 +47,7 @@ Factions of Orcs, Elves, Dwarves, and Drakes are on a rampage. Only your genocid
 
   [event]
     name=start
-    {SXC_ARMORY_LIMIT 1}
-    {SXC_ARMORY_LIMIT 2}
-    {SXC_ARMORY_LIMIT 3}
-    {SXC_ARMORY_LIMIT 4}
-    {SXC_ARMORY_LIMIT 5}
-    {SXC_NO_GOLD_FOR_NOBODY}
+    {SXC_ARMORY_LIMITS_AND_EMPTY_SIDES}
 
     {SXC_BEFORE_SHOPS}
     {SXC_SHOP_2 2 25 "scenery/tent-shop-weapons.png"}

--- a/scen_gol/SXC_Simple.cfg
+++ b/scen_gol/SXC_Simple.cfg
@@ -3,7 +3,7 @@
   id=SXC_Simple_{SXC_VERSION}
   name="SXC Simple {SXC_VERSION}"
   map_data="{~add-ons/SXCollection/maps/SXC_Simple.map}"
-  description= _ "You have to try to kill all leaders or survive until the turn limit expires. You play only with your leader but you can enhance it during the game. You get gold, extra moves and attack for every enemy you kill. Use default map settings otherwise you will lose immediately. Best use the SXC or SurivalXtreme Era. Have fun!"
+  description={SXC_MAP_DEFAULT_DESCRIPTION}
   {SXC_DEFAULT_MAP_SETTINGS 90 "win" "data/core/images/portraits/drakes/clasher.png" "<span color='#BCB088' weight='bold' face='roman'>Map by Golbeeze
 Survive as long as possible while trying to kill the enemy leaders. You receive money for every kill which you want to spend in the shop.
 Factions of Orcs, Elves, Dwarves, and Drakes are on a rampage. Only your genocidal rampages can stop them! Enjoy!</span>"}

--- a/scen_gol/SXC_Spiral.cfg
+++ b/scen_gol/SXC_Spiral.cfg
@@ -3,8 +3,7 @@
   id=SXC_Spiral_{SXC_VERSION}
   name="SXC Spiral {SXC_VERSION}"
   map_data="{~add-ons/SXCollection/maps/SXC_Spiral.map}"
-  description= _ "This map requires Ageless Era!
-Survive and kill the enemy leaders before turns expire. You receive money for every kill which you want in the shop to improve your unit. Best use the SXC or SurivalXtreme Era."
+  description={SXC_MAP_NOTES_REQUIRES_AGELESS} + {SXC_MAP_DEFAULT_DESCRIPTION}
   {SXC_DEFAULT_MAP_SETTINGS 90 "lose" "~add-ons/Ageless_Era/images/units/fiends/lucifer.png" "<span color='#BCB088' weight='bold' face='roman'>Map by Golbeeze
 Kill the enemy leaders before turns expire. You receive money for every kill which you want to spend in the shop.
 You and your fellow warriors are trapped within a death maze. There is only one way out: through your battle-hardened opponents! Enjoy!</span>"}

--- a/scen_gol/SXC_Spiral.cfg
+++ b/scen_gol/SXC_Spiral.cfg
@@ -46,12 +46,7 @@ You and your fellow warriors are trapped within a death maze. There is only one 
 
   [event]
     name=start
-    {SXC_ARMORY_LIMIT 1}
-    {SXC_ARMORY_LIMIT 2}
-    {SXC_ARMORY_LIMIT 3}
-    {SXC_ARMORY_LIMIT 4}
-    {SXC_ARMORY_LIMIT 5}
-    {SXC_NO_GOLD_FOR_NOBODY}
+    {SXC_ARMORY_LIMITS_AND_EMPTY_SIDES}
 
     {SXC_BEFORE_SHOPS}
     {SXC_SHOP_2 25 17 "terrain/village/human-city.png"}

--- a/scen_gol/SXC_Trapped.cfg
+++ b/scen_gol/SXC_Trapped.cfg
@@ -47,12 +47,7 @@ The enemy forces have set up a devious encampment utilizing the land to their ad
 
   [event]
     name=start
-    {SXC_ARMORY_LIMIT 1}
-    {SXC_ARMORY_LIMIT 2}
-    {SXC_ARMORY_LIMIT 3}
-    {SXC_ARMORY_LIMIT 4}
-    {SXC_ARMORY_LIMIT 5}
-    {SXC_NO_GOLD_FOR_NOBODY}
+    {SXC_ARMORY_LIMITS_AND_EMPTY_SIDES}
 
     {SXC_BEFORE_SHOPS}
     {SXC_SHOP_2 4 3 "scenery/tent-shop-weapons.png"}

--- a/scen_gol/SXC_Trapped.cfg
+++ b/scen_gol/SXC_Trapped.cfg
@@ -3,7 +3,7 @@
   id=SXC_Trapped_{SXC_VERSION}
   name="SXC Trapped {SXC_VERSION}"
   map_data="{~add-ons/SXCollection/maps/SXC_Trapped.map}"
-  description= _ "You have to try to kill all leaders or survive until the turn limit expires. You play only with your leader but you can enhance it during the game. You get gold, extra moves and attack for every enemy you kill. Use default map settings otherwise you will lose immediately. Best use the SXC or SurivalXtreme Era. Have fun!"
+  description={SXC_MAP_DEFAULT_DESCRIPTION}
   {SXC_DEFAULT_MAP_SETTINGS 90 "lose" "data/core/images/portraits/undead/revenant.png" "<span color='#BCB088' weight='bold' face='roman'>Map by Golbeeze
 Survive as long as possible while trying to kill the enemy leaders. You receive money for every kill which you want to spend in the shop.
 The enemy forces have set up a devious encampment utilizing the land to their advantage. You must Fight through and defeat the enemy generals to stop the onslaught! Enjoy!</span>"}

--- a/scen_new/SXC_CursedLand.cfg
+++ b/scen_new/SXC_CursedLand.cfg
@@ -3,8 +3,7 @@
   id=SXC_CursedLand_{SXC_VERSION}
   name="SXC Cursed Land {SXC_VERSION}"
   map_data="{~add-ons/SXCollection/maps/SXC_CursedLand.map}"
-  description= _ "This map requires Ageless Era!
-You have to defeat all enemy Leaders. You start with only one unit, but you can enhance it during the game. A turn limit means you have to win until it ends. Use default settings or you will lose immediately. Best use the SXC or SurivalXtreme Era."
+  description={SXC_MAP_NOTES_REQUIRES_AGELESS} + {SXC_MAP_DEFAULT_DESCRIPTION}
   {SXC_DEFAULT_MAP_SETTINGS 84 "lose" "data/core/images/portraits/humans/necromancer.png" "<span color='#BCB088' weight='bold' face='roman'>Map by -stf-
 Somewhere beyond the old abandoned dwarven mines is place penetrated by dark magic, where everybody, who stays there for longer time than 14 days, becomes cursed and serves to dark forces, no matter how strong his/her own magical resistance is. You are comming in this place together with other volunteers to find source of this dark magic and to clear this place of all enemy leaders, who are cursed too long to become normal again. If you will not kill all enemy leaders within specified time (14 days = 84 turns), you will be cursed too and you will lose. Anyone of first 3 enemy leaders can summon back last leader every 2 days, so when he is killed before them, hurry to kill them, before they will summon him back. There will also arrive some strong bosses every 10 turns. But for now, have fun and good luck!</span>"}
 

--- a/scen_new/SXC_CursedLand.cfg
+++ b/scen_new/SXC_CursedLand.cfg
@@ -73,12 +73,7 @@ Somewhere beyond the old abandoned dwarven mines is place penetrated by dark mag
 
   [event]
     name=start
-    {SXC_ARMORY_LIMIT 1}
-    {SXC_ARMORY_LIMIT 2}
-    {SXC_ARMORY_LIMIT 3}
-    {SXC_ARMORY_LIMIT 4}
-    {SXC_ARMORY_LIMIT 5}
-    {SXC_NO_GOLD_FOR_NOBODY}
+    {SXC_ARMORY_LIMITS_AND_EMPTY_SIDES}
 
     {SXC_BEFORE_SHOPS}
     {SXC_SHOP_2 39 2 "terrain/village/human-city3.png"}

--- a/scen_new/SXC_IsleOfTheDead.cfg
+++ b/scen_new/SXC_IsleOfTheDead.cfg
@@ -45,12 +45,7 @@ Legends tell of far islands, about unhuman beings worship their dark gods and of
 
   [event]
     name=start
-    {SXC_ARMORY_LIMIT 1}
-    {SXC_ARMORY_LIMIT 2}
-    {SXC_ARMORY_LIMIT 3}
-    {SXC_ARMORY_LIMIT 4}
-    {SXC_ARMORY_LIMIT 5}
-    {SXC_NO_GOLD_FOR_NOBODY}
+    {SXC_ARMORY_LIMITS_AND_EMPTY_SIDES}
 
     {SXC_BEFORE_SHOPS}
     {SXC_SHOP_2 3 45 "terrain/village/human-city3.png~FL()"}

--- a/scen_new/SXC_IsleOfTheDead.cfg
+++ b/scen_new/SXC_IsleOfTheDead.cfg
@@ -3,8 +3,7 @@
   id=SXC_IsleOfTheDead_{SXC_VERSION}
   name="SXC Isle of the Dead {SXC_VERSION}"
   map_data="{~add-ons/SXCollection/maps/SXC_IsleOfTheDead.map}"
-  description= _ "This map requires Ageless Era!
-You have to defeat all enemy Leaders. You start with only one unit, but you can enhance it during the game. You get gold for every unit you kill. A turn limit means you have to win until it ends. Best use the SXC or SurivalXtreme Era. Have Fun!"
+  description={SXC_MAP_NOTES_REQUIRES_AGELESS} + {SXC_MAP_DEFAULT_DESCRIPTION}
   {SXC_DEFAULT_MAP_SETTINGS 150 "lose" "data/core/images/portraits/humans/necromancer.png" "<span color='#BCB088' weight='bold' face='roman'>Map by Mabuse
 Legends tell of far islands, about unhuman beings worship their dark gods and of sunken cities inhabited by giantic sea serpents. Rumors about a destroyed outpost on a far island convinced the King to send some of his best men to explore and annihilate possible threats. Defeat all enemy leaders to win. Leaders wont respawn, except the last one, which may respawn if there are other leaders still alive, so kill them on sight. You can enhance your unit for gold in shops. For any unit you kill you get gold and gain 4 MP back, what allows you to attack as long as possible. There will also appear some exceptionally strong bosses later and the creeps will become stronger over time. But for now, have fun!</span>"}
 

--- a/scen_new/SXC_Light_Cave.cfg
+++ b/scen_new/SXC_Light_Cave.cfg
@@ -2,7 +2,7 @@
   id=SXC_Light_Cave_{SXC_VERSION}
   name="SXC Light Cave {SXC_VERSION}"
   map_data="{~add-ons/SXCollection/maps/SXC_Light_Cave.map}"
-  description= _ "You have to try to kill all leaders until the turn limit expires or you will lose. You play only with your leader but you can enhance it during the game. You get gold, extra moves and attack for every enemy you kill. Use default map settings otherwise you will lose immediately. Best use the SXC or SurivalXtreme Era. Have fun!"
+  description={SXC_MAP_DEFAULT_DESCRIPTION}
   {SXC_DEFAULT_MAP_SETTINGS 200 "win" "story/landscape-bridge.jpg" "<span color='#BCB088' size='small' weight='bold' face='roman'>You and your party take cover inside a cave from a coming blizzard. But this cave is more than it appears at a glance. Created by Light, With assistance from SpoOky</span>"}
 
 #   {SXC_TEST_PLAYER_SIDE_2 1 800 (color=red)}

--- a/scen_new/SXC_Light_Cave.cfg
+++ b/scen_new/SXC_Light_Cave.cfg
@@ -42,12 +42,7 @@
 
   [event]
     name=start
-    {SXC_ARMORY_LIMIT 1}
-    {SXC_ARMORY_LIMIT 2}
-    {SXC_ARMORY_LIMIT 3}
-    {SXC_ARMORY_LIMIT 4}
-    {SXC_ARMORY_LIMIT 5}
-    {SXC_NO_GOLD_FOR_NOBODY}
+    {SXC_ARMORY_LIMITS_AND_EMPTY_SIDES}
 
     {SXC_BEFORE_SHOPS}
     {SXC_SHOP_2 37 31 "terrain/village/human-city.png"}

--- a/scen_new/SXC_MountainsOfDoom.cfg
+++ b/scen_new/SXC_MountainsOfDoom.cfg
@@ -45,12 +45,7 @@ Legends tell about old tombs full of treasure hidden in these snowy passes. In t
 
   [event]
     name=start
-    {SXC_ARMORY_LIMIT 1}
-    {SXC_ARMORY_LIMIT 2}
-    {SXC_ARMORY_LIMIT 3}
-    {SXC_ARMORY_LIMIT 4}
-    {SXC_ARMORY_LIMIT 5}
-    {SXC_NO_GOLD_FOR_NOBODY}
+    {SXC_ARMORY_LIMITS_AND_EMPTY_SIDES}
 
     {SXC_BEFORE_SHOPS}
     {SXC_SHOP_2 33 39 "terrain/village/human-city3.png"}

--- a/scen_new/SXC_MountainsOfDoom.cfg
+++ b/scen_new/SXC_MountainsOfDoom.cfg
@@ -3,8 +3,7 @@
   id=SXC_MountainsOfDoom_{SXC_VERSION}
   name="SXC Mountains of Doom {SXC_VERSION}"
   map_data="{~add-ons/SXCollection/maps/SXC_MountainsOfDoom.map}"
-  description= _ "This map requires Ageless Era!
-You have to defeat all enemy Leaders. You start with only one unit, but you can enhance it during the game. You get gold for every unit you kill. A turn limit means you have to win until it ends. Best use the SXC or SurivalXtreme Era. Have Fun!"
+  description={SXC_MAP_NOTES_REQUIRES_AGELESS} + {SXC_MAP_DEFAULT_DESCRIPTION}
   {SXC_DEFAULT_MAP_SETTINGS 150 "lose" "data/core/images/portraits/humans/necromancer.png" "<span color='#BCB088' weight='bold' face='roman'>Map by Mabuse
 Legends tell about old tombs full of treasure hidden in these snowy passes. In these mountains dark elves celebrate unholy rites to raise an army of undead warriors. Defeat all enemy leaders to win. Leaders wont respawn, except the last one, which may respawn if there are other leaders still alive, so kill them on sight. You can enhance your unit in shops for gold. For any unit you kill you get gold and gain 4 MP back, what allows you to attack as long as possible. There will also appear some exceptionally strong bosses later, and the creeps will become stronger over time. But for now, have fun!</span>"}
 

--- a/scen_new/SXC_Pressure.cfg
+++ b/scen_new/SXC_Pressure.cfg
@@ -410,16 +410,16 @@
     [/filter]
     [message]
       speaker=narrator
-      message="Choose the variantion of this map to play. All variations can be completed with any normal hero's default movement types, but the variant will affect how easy it is to move around the map at the start. The normal difficulty levels (rookie, advanced, xtreme, mad mode) can be selected in the next dialog."
+      message=_ "Choose the variantion of this map to play. All variations can be completed with any normal hero's default movement types, but the variant will affect how easy it is to move around the map at the start. The normal difficulty levels (rookie, advanced, xtreme, mad mode) can be selected in the next dialog."
       [option]
-        message="Shallow Water (easier)"
+        message=_ "Shallow Water (easier)"
         [command]
           {VARIABLE sxcp_map_variant_text "Variant: Shallow Water"}
           {VARIABLE sxcp_lake_sluice_open yes}
         [/command]
       [/option]
       [option]
-        message="*Mermaid's Lake (harder)"
+        message=_ "*Mermaid's Lake (harder)"
         [command]
           {VARIABLE sxcp_map_variant_text "Variant: Mermaid's Lake"}
           {VARIABLE sxcp_lake_sluice_open no}

--- a/scen_new/SXC_Pressure.cfg
+++ b/scen_new/SXC_Pressure.cfg
@@ -92,12 +92,7 @@
 
   [event]
     name=start
-    {SXC_ARMORY_LIMIT 1}
-    {SXC_ARMORY_LIMIT 2}
-    {SXC_ARMORY_LIMIT 3}
-    {SXC_ARMORY_LIMIT 4}
-    {SXC_ARMORY_LIMIT 5}
-    {SXC_NO_GOLD_FOR_NOBODY}
+    {SXC_ARMORY_LIMITS_AND_EMPTY_SIDES}
 
     {SXC_BEFORE_SHOPS}
     {SXC_SHOP_2 2 19 "terrain/village/human-city3.png"}

--- a/scen_new/SXC_Pressure.cfg
+++ b/scen_new/SXC_Pressure.cfg
@@ -33,7 +33,7 @@
   id=SXC_Pressure_{SXC_VERSION}
   name="SXC Pressure {SXC_VERSION}"
   map_data="{~add-ons/SXCollection/maps/SXC_Pressure.map}"
-  description= _ "You have to defeat all enemy Leaders. You start with only one unit, but you can enhance it during the game. A turn limit means you have to win until it ends. Use default settings or you will lose immediately. Best use the SXC or SurvivalXtreme Era."
+  description={SXC_MAP_DEFAULT_DESCRIPTION}
 # For Wesnoth 1.13, data/core/images/portraits/undead/zombie-swimmer.png would be better
   {SXC_DEFAULT_MAP_SETTINGS 150 "lose" "data/core/images/portraits/merfolk/priestess.png" "<span color='#BCB088' weight='bold' face='roman'>This area was once a thermal spa, where warm water formed a lake before flowing back underground. Over time the dwarves took over the warmest corner, with other groups claiming their own areas; recently dark sorcery has taken over the lake, and the undead swim in it. You start with only one unit, but you can enhance it during the game. Have fun and good luck!</span>"}
 

--- a/scen_new/SXC_Slaughter.cfg
+++ b/scen_new/SXC_Slaughter.cfg
@@ -5,7 +5,7 @@
 id=multiplayer_SXC_Slaughter
 name="SXC_Slaughter"
 map_data="{~add-ons/SXCollection/maps/SXC_Slaughter.map}"
-description= _ "You have to try to kill all leaders or survive until the turn limit expires. You play only with your leader but you can enhance it during the game. You get gold, extra moves and attack for every enemy you kill. Use default map settings otherwise you will lose immediately. Best use the SXC or SurivalXtreme Era. Have fun!"
+description={SXC_MAP_NOTES_REQUIRES_AGELESS} + {SXC_MAP_DEFAULT_DESCRIPTION} + {SXC_MAP_NOTES_NEW_PARAGRAPH} + _ "After realizing that your neighbors are just occupying space you could be using, and consuming resources that could best be used to feed you, you decide that they should rightfully be removed from the world of the living. Lets the genocide begin!" + {SXC_MAP_NOTES_NEW_PARAGRAPH} + "MAP by pkz   edited and fixed by Jordy"
 {SXC_DEFAULT_MAP_SETTINGS 100 "lose" "story/landscape-battlefield.jpg" "<span color='#BCB088' size='small' weight='bold' face='roman'>After realizing that your neighbors are just occupying space you could be using, and consuming resources that could best be used to feed you, you decide that they should rightfully be removed from the world of the living. Lets the genocide begin!
 
  MAP by pkz   edited and fixed by Jordy </span>"}

--- a/scen_new/SXC_Slaughter.cfg
+++ b/scen_new/SXC_Slaughter.cfg
@@ -67,13 +67,8 @@ description= _ "You have to try to kill all leaders or survive until the turn li
  
   [event]
     name=start
-    {SXC_ARMORY_LIMIT 1}
-    {SXC_ARMORY_LIMIT 2}
-    {SXC_ARMORY_LIMIT 3}
-    {SXC_ARMORY_LIMIT 4}
-    {SXC_ARMORY_LIMIT 5}
-    {SXC_NO_GOLD_FOR_NOBODY}
-    
+    {SXC_ARMORY_LIMITS_AND_EMPTY_SIDES}
+
     {SXC_BEFORE_SHOPS}
     {SXC_SHOP_2 72 38 "terrain/village/human-city.png"}
     {SXC_SHOP_2 62 23 "terrain/village/human-city.png"}

--- a/scen_new/SXC_SpoOky_Forest.cfg
+++ b/scen_new/SXC_SpoOky_Forest.cfg
@@ -14,7 +14,7 @@
   id=SXC_SpoOky_Forest_{SXC_VERSION}
   name="SXC SpoOky's Forest {SXC_VERSION}"
   map_data="{~add-ons/SXCollection/maps/SXC_SpoOky_Forest.map}"
-  description= _ "You have to try to kill all leaders until the turn limit expires or you will lose. You play only with your leader but you can enhance it during the game. You get gold, extra moves and attack for every enemy you kill. Use default map settings otherwise you will lose immediately. Best use the SXC or SurivalXtreme Era. Have fun!"
+  description={SXC_MAP_DEFAULT_DESCRIPTION}
   {SXC_DEFAULT_MAP_SETTINGS 90 "lose" "story/landscape-battlefield.jpg" "<span color='#BCB088' size='small' weight='bold' face='roman'>It seems you and your friends are lost within a forest. Suddenly, you noticed that you are being chased by the undead! You must escape the forest with their lives or die trying...
 Unfortunately the only way to get out alive is to kill all enemy leaders. Will you get out alive?</span>"}
 

--- a/scen_new/SXC_SpoOky_Forest.cfg
+++ b/scen_new/SXC_SpoOky_Forest.cfg
@@ -163,12 +163,7 @@ Unfortunately the only way to get out alive is to kill all enemy leaders. Will y
 
   [event]
     name=start
-    {SXC_ARMORY_LIMIT 1}
-    {SXC_ARMORY_LIMIT 2}
-    {SXC_ARMORY_LIMIT 3}
-    {SXC_ARMORY_LIMIT 4}
-    {SXC_ARMORY_LIMIT 5}
-    {SXC_NO_GOLD_FOR_NOBODY}
+    {SXC_ARMORY_LIMITS_AND_EMPTY_SIDES}
 
     {SXC_BEFORE_SHOPS}
     {SXC_SHOP_2 6 38 "terrain/village/human-city.png"}

--- a/scen_new/SXC_Storm_Castle.cfg
+++ b/scen_new/SXC_Storm_Castle.cfg
@@ -2,7 +2,9 @@
     id=multiplayer_SXC_Storm_Castle
     name="SXC_Storm_Castle"
     map_data="{~add-ons/SXCollection/maps/SXC_Storm_Castle.map}"
-    description= _ "You have to try to kill all leaders or survive until the turn limit expires. You play only with your leader but you can enhance it during the game. You get gold, extra moves and attack for every enemy you kill. Use default map settings otherwise you will lose immediately. Best use the SXC or SurivalXtreme Era. Have fun!"
+    description={SXC_MAP_DEFAULT_DESCRIPTION} + {SXC_MAP_NOTES_NEW_PARAGRAPH} + _ "After much troubles, the Dwarves reached the summit of glory, and restored an old abandoned human castle because a mage went too far into the darkness. They use this castle to get an outer defense using any faction trading with them, even the undead.
+But the general's soul and companion souls have been corrupted by the aura of darkness that reigned there. They began to eliminate any stranger who ventured into their areas to then chase the survivors and attack their kingdoms.
+Fortunately they spared the youngest of whom you are a part.You and your troop must release this castle and avenge your martyrs." + {SXC_MAP_NOTES_NEW_PARAGRAPH} + _ "Created by pkz, updated and corrected by Jordy"
 {SXC_DEFAULT_MAP_SETTINGS 100 "win" "story/landscape-castle.jpg" "<span color='#BCB088' size='small' weight='bold' face='roman'>After much troubles, the Dwarves reached the summit of glory, and restored an old abandoned human castle because a mage went too far into the darkness. They use this castle to get an outer defense using any faction trading with them, even the undead.
 But the general's soul and companion souls have been corrupted by the aura of darkness that reigned there. They began to eliminate any stranger who ventured into their areas to then chase the survivors and attack their kingdoms.
 Fortunately they spared the youngest of whom you are a part.You and your troop must release this castle and avenge your martyrs. 

--- a/scen_new/SXC_Storm_Castle.cfg
+++ b/scen_new/SXC_Storm_Castle.cfg
@@ -422,13 +422,8 @@ Created by pkz, updated and corrected by Jordy</span>"}
   
   [event]
     name=start
-    {SXC_ARMORY_LIMIT 1}
-    {SXC_ARMORY_LIMIT 2}
-    {SXC_ARMORY_LIMIT 3}
-    {SXC_ARMORY_LIMIT 4}
-    {SXC_ARMORY_LIMIT 5}
-    {SXC_NO_GOLD_FOR_NOBODY}
-    
+    {SXC_ARMORY_LIMITS_AND_EMPTY_SIDES}
+
     {SXC_BEFORE_SHOPS}
     {SXC_SHOP_2 04 23 "terrain/village/dwarven.png"}
     {SXC_SHOP_2 37 03 "terrain/village/human-city3.png"}

--- a/scen_new/SXC_WizardOfWar.cfg
+++ b/scen_new/SXC_WizardOfWar.cfg
@@ -45,12 +45,7 @@ Legend tells about a terrible old Evil deep in the Mountains. Defeat all enemy l
 
   [event]
     name=start
-    {SXC_ARMORY_LIMIT 1}
-    {SXC_ARMORY_LIMIT 2}
-    {SXC_ARMORY_LIMIT 3}
-    {SXC_ARMORY_LIMIT 4}
-    {SXC_ARMORY_LIMIT 5}
-    {SXC_NO_GOLD_FOR_NOBODY}
+    {SXC_ARMORY_LIMITS_AND_EMPTY_SIDES}
 
     {SXC_BEFORE_SHOPS}
     {SXC_SHOP_2 37 31 "terrain/village/human-city3.png"}

--- a/scen_new/SXC_WizardOfWar.cfg
+++ b/scen_new/SXC_WizardOfWar.cfg
@@ -3,7 +3,7 @@
   id=SXC_WizardOfWar_{SXC_VERSION}
   name="SXC Wizard Of War {SXC_VERSION}"
   map_data="{~add-ons/SXCollection/maps/SXC_WizardOfWar.map}"
-  description= _ "You have to defeat all enemy Leaders. You start with only one unit, but you can enhance it during the game. A turn limit means you have to win until it ends. Best use the SXC or SurivalXtreme Era. Have fun!"
+  description={SXC_MAP_DEFAULT_DESCRIPTION} + {SXC_MAP_NOTES_NEW_PARAGRAPH} +_ "Legend tells about a terrible old Evil deep in the Mountains." + {SXC_MAP_NOTES_NEW_PARAGRAPH} +  _ "*** Mod by Mabuse and Clonkinator, further changes by pkz,-stf- ***"
   {SXC_DEFAULT_MAP_SETTINGS 125 "win" "data/core/images/portraits/humans/necromancer+female.png" "<span color='#BCB088' weight='bold' face='roman'>*** Mod by Mabuse and Clonkinator, further changes by pkz,-stf- ***
 Legend tells about a terrible old Evil deep in the Mountains. Defeat all enemy leaders to win. Leaders wont respawn, except the last one, which may respawn if there are other Leaders still alive, so kill them on sight. There are shops in which you can enhance your unit for gold. For any unit you kill you get gold and gain 4 MP back, what allows you to attack as long as possible. There will also appear some exceptionally strong bosses later, and the creeps will become stronger over time. Special items found on the map can also improve your unit as long as you have them in inventory. Have fun!</span>"}
 


### PR DESCRIPTION
Two changes that touch every map

Only run the armoury checks for sides with leaders (solves some wml warnings when playing with less than 5 players)

Each map shows its own description. All of them already had their own description, but the description in SXCmacros.cfg overrode them. Remove that, and also add macros for the standard texts.

This puts the "this map requires Ageless Era" text first, so that the whole description changes visibly when scrolling through the list of maps to choose which game to create.

Also, do not recommend an era, as it would be wrong for Ageless maps.