### PR TITLE
SXC Remove buggy code related to the fearless trait

### DIFF
--- a/macros/SXCmacros.cfg
+++ b/macros/SXCmacros.cfg
@@ -524,35 +524,6 @@
 #enddef
 
 #define SXC_ABILITIES_REPLACEMENT SIDE
-  [store_unit]
-    [filter]
-      side={SIDE}
-      canrecruit=yes
-      [filter_wml]
-        [trait]
-          id=fearless
-        [/trait]
-      [/filter_wml]
-      [not]
-        [filter_wml]
-          [trait]
-            availability=musthave
-            id=fearless
-          [/trait]
-        [/filter_wml]
-      [/not]
-    [/filter]
-    variable=trait_fearless
-  [/store_unit]
-  {VARIABLE new_trait $trait_fearless.modifications.trait.length}
-  {VARIABLE trait_fearless.modifications.trait[$new_trait|].id ("fearless")}
-  {VARIABLE trait_fearless.modifications.trait[$new_trait|].male_name (_ "fearless")}
-  {VARIABLE trait_fearless.modifications.trait[$new_trait|].female_name (_ "female^fearless")}
-  {VARIABLE trait_fearless.modifications.trait[$new_trait|].description (_ "Fights normally during unfavorable times of day/night")}
-  [unstore_unit]
-    variable=trait_fearless
-  [/unstore_unit]
-  {CLEAR_VARIABLE trait_fearless}
   [object]
     silent=yes
     duration=forever


### PR DESCRIPTION
This code makes no sense to me, AFAICS if it wasn't buggy then for units with
the fearless trait it would remove that trait, and then replace it again with
a fearless trait.

It's buggy, because if the unit doesn't have fearless then the [store_unit]
doesn't find a unit. On both 1.12.6 and 1.13 the [unstore_unit] complains that
the variable doesn't contain unit data; on 1.13.11 it's an error which stops the
WML processing and therefore causes issue #24 (the conversion of abilities to
megacures etc is skipped).

This causes issue #24, and is one of the problems in issue #22.