### PR TITLE
SXC In revive mode, add a note about respawning to the death messages

### DIFF
--- a/macros/SXCmacros.cfg
+++ b/macros/SXCmacros.cfg
@@ -290,16 +290,73 @@
   {VARIABLE precision_combinations ",attack_only,backstab,charm,cleave,dread,evade,evasion,firststrike,highground,nocounter,poison,rage,rage2,rage3,recieve,slow,spread,sxc_evade,sxc_rage,triplestrike,"}
   {VARIABLE rage_combinations ",attack_only,blind,charm,cleave,dread,evade,evasion,ferocious,firststrike,focus,guided,magical,marksman,massivestrike,poison,precision,recieve,slow,spread,sxc_evade,sxc_focus,sxc_precision,"}
   {VARIABLE slow_combinations ",arson,attack_only,backstab,blind,charge,charm,circle,cleave,concentrated,counter,defend_only,drains,dread,evade,evasion,ferocious,firststrike,focus,guided,highground,magical,marksman,massivestrike,nocounter,poison,precision,rage,rage2,rage3,recieve,return,spread,sxc_evade,sxc_focus,sxc_precision,sxc_rage,triplestrike,udbane,"}
-  {VARIABLE death_text_0 "Argh... I guess that was my last adventure..."}
-  {VARIABLE death_text_1 "This cannot be..."}
-  {VARIABLE death_text_2 "I'm... dying..."}
-  {VARIABLE death_text_3 "Urgh. I should never have come here..."}
-  {VARIABLE death_text_4 "Argh. I'm done for."}
-  {VARIABLE death_text_5 "Sorry... friends... i can't..."}
-  {VARIABLE death_text_6 "Why... me..."}
-  {VARIABLE death_text_7 "This really... hurts..."}
-  {VARIABLE death_text_8 "Where is my gold..."}
-  {VARIABLE death_text_9 "I can't die... now..."}
+  # These are used in non-revive mode
+  [set_variables]
+    name=death_texts_dead
+    mode=replace
+    [value]
+      value=_ "dead^Argh... I guess that was my last adventure..."
+    [/value]
+    [value]
+      value=_ "dead^This cannot be..."
+    [/value]
+    [value]
+      value=_ "dead^I'm... dying..."
+    [/value]
+    [value]
+      value=_ "dead^Urgh. I should never have come here..."
+    [/value]
+    [value]
+      value=_ "dead^Argh. I'm done for."
+    [/value]
+    [value]
+      value=_ "dead^Sorry... friends... i can't..."
+    [/value]
+    [value]
+      value=_ "dead^Why... me..."
+    [/value]
+    [value]
+      value=_ "dead^This really... hurts..."
+    [/value]
+    [value]
+      value=_ "dead^Where is my gold..."
+    [/value]
+    [value]
+      value=_ "dead^I can't die... now..."
+    [/value]
+  [/set_variables]
+  # These are used revive mode, with a note that the character will revive added
+  [set_variables]
+    name=death_texts_revive
+    mode=replace
+    [value]
+      value=_ "revive^This could be my last adventure..."
+    [/value]
+    [value]
+      value=_ "revive^This cannot be..."
+    [/value]
+    [value]
+      value=_ "revive^Back to the shop..."
+    [/value]
+    [value]
+      value=_ "revive^I must reach the shop..."
+    [/value]
+    [value]
+      value=_ "revive^Urgh. I should never have come here..."
+    [/value]
+    [value]
+      value=_ "revive^Argh. I need to retreat..."
+    [/value]
+    [value]
+      value=_ "revive^Sorry... friends... i can't..."
+    [/value]
+    [value]
+      value=_ "revive^Why... me..."
+    [/value]
+    [value]
+      value=_ "revive^Where is my gold..."
+    [/value]
+  [/set_variables]
   {VARIABLE recruits_6 0}
   {VARIABLE recruits_7 0}
   {VARIABLE recruits_8 0}
@@ -6034,7 +6091,7 @@ Recruits alive side 9: $recruits_9|"
       [/command]
     [/set_menu_item]
     [if]
-      {SXC_CMP revive equals "yes"}
+      {SXC_CMP revive boolean_equals yes}
       [then]
         {VARIABLE helptext "<span color='#40FF40' size='large'>Help for beginners</span>
 To show this help text any time later, right click and choose 'SXCollection Help'
@@ -6108,7 +6165,6 @@ $maptext|"
       side=1,2,3,4,5
       canrecruit=yes
     [/filter]
-    {RANDOM 0..9}
     [store_unit]
       [filter]
         x,y=$x1,$y1
@@ -6116,16 +6172,37 @@ $maptext|"
       [/filter]
       variable=dying_friend
     [/store_unit]
+    [if]
+      {SXC_CMP revive boolean_equals yes}
+      [then]
+        [set_variables]
+          name=death_texts
+          to_variable=death_texts_revive
+        [/set_variables]
+        {VARIABLE death_text_suffix (_"
+<span color='lightgreen'>Revive mode is on, the unit will respawn if at least one player unit survives this turn</span>")}
+      [/then]
+      [else]
+        [set_variables]
+          name=death_texts
+          to_variable=death_texts_dead
+        [/set_variables]
+        {VARIABLE death_text_suffix ""}
+      [/else]
+    [/if]
+    {RANDOM 0..$death_texts.length}
     [message]
       speaker=unit
-      message="$death_text_$random||"
+      message="$death_texts[$random|].value| $death_text_suffix|"
     [/message]
+    {CLEAR_VARIABLE death_texts}
+    {CLEAR_VARIABLE death_text_suffix}
     [store_gold]
       side=$dying_friend.side
       variable=gold_die
     [/store_gold]
     [if]
-      {SXC_CMP revive equals "yes"}
+      {SXC_CMP revive boolean_equals yes}
       [then]
         {VARIABLE deads $dead.length}
         [store_unit]


### PR DESCRIPTION
The messages for revive mode can now be different to the messages
for death mode, and the random-selection code has been updated.