### PR TITLE
SXC Avoid the WML error about unstoring 'leader' which doesn't contain unit data

### DIFF
--- a/macros/SXCmacros.cfg
+++ b/macros/SXCmacros.cfg
@@ -7210,21 +7210,42 @@ $maptext|"
     {CLEAR_VARIABLE i}
     {VARIABLE_OP recruits_$side_number add 1}
     [if]
-      {SXC_CMP recruits_$side_number greater_than 30}
+      {SXC_CMP side_number less_than 6}
       [then]
-        [store_unit]
-          [filter]
-            side=$side_number
-            role="big_boss"
-          [/filter]
-          variable=leader
-        [/store_unit]
-        {VARIABLE leader.canrecruit "no"}
-        [unstore_unit]
-          variable=leader
-        [/unstore_unit]
-        {CLEAR_VARIABLE leader}
+        # Show a console warning for bug #33 instead of trigging a WML error
+        #
+        # A proper fix will be (now that we have Wesnoth 1.14's support for more sides) to convert
+        # all fake sides to real sides. That will have a small effect on map balance, as the fake
+        # sides recruited at the start of each turn, even for turn 1.
+        #
+        # It doesn't affect the recruit limits of the real sides - recruits for fake sides are
+        # labelled by setting "unit.role=fake_recruits", which means killing them doesn't change the
+        # recruit count of the real side; and this role was set even if a WML error occured here, as
+        # it's done in a separate event.
+        [wml_message]
+          message="SXC bug #33: fake side's recruits would be accounted to side $side_number|"
+          logger=warn
+        [/wml_message]
       [/then]
+      [else]
+        [if]
+          {SXC_CMP recruits_$side_number greater_than 30}
+          [then]
+            [store_unit]
+              [filter]
+                side=$side_number
+                role="big_boss"
+              [/filter]
+              variable=leader
+            [/store_unit]
+            {VARIABLE leader.canrecruit "no"}
+            [unstore_unit]
+              variable=leader
+            [/unstore_unit]
+            {CLEAR_VARIABLE leader}
+          [/then]
+        [/if]
+      [/else]
     [/if]
   [/event]
 #enddef


### PR DESCRIPTION
A console warning will still be printed, see the comments in the
code for why the underlying bug is being hidden instead of fixed.