### PR TITLE
SXC Storm Castle show a slave's portrait when the slaves thank you for freeing them

### DIFF
--- a/scen_new/SXC_Storm_Castle.cfg
+++ b/scen_new/SXC_Storm_Castle.cfg
@@ -787,7 +787,8 @@ Created by pkz, updated and corrected by Jordy</span>"}
       side=1,2,3,4,5
     [/filter]
     [message]
-      speaker=unit
+      speaker=narrator
+      image=portraits/humans/footpad.png
       message= "This is the slave quarters. Please spare us. We can tell you of a man who lives on the Frozen Mountain. He knows how to find powerful artifacts"
     [/message]
  #   [sound]


### PR DESCRIPTION
Using a ruffian's portrait for this, the main point is that it's
not the player's unit's own portrait.