### PR TITLE
SXC Spooky Forest Fix a bug with Pokey

### DIFF
--- a/scen_new/SXC_SpoOky_Forest.cfg
+++ b/scen_new/SXC_SpoOky_Forest.cfg
@@ -321,7 +321,7 @@ Unfortunately the only way to get out alive is to kill all enemy leaders. Will y
       name=Master of Poking
       role=big_boss
       id=Boss_10
-      {IS_HERO}
+      {IS_EXPENDABLE_LEADER}
       ai_special=guardian
       unrenamable=yes
       {SXC_ENEMY_UNIT_MODIFICATIONS set 2 72 0 0 0 0 40 SWP BLANK BLANK BLANK {TRAIT_LOYAL} {BLANK}}
@@ -335,6 +335,19 @@ Unfortunately the only way to get out alive is to kill all enemy leaders. Will y
     {SXC_ENEMY_GUARD_CHANGE_ARMOR 10 14 9 cold 100}
     {SXC_ENEMY_GUARD_CHANGE_ARMOR 10 14 9 fire 100}
     {SXC_ENEMY_GUARD_CHANGE_ARMOR 10 14 9 arcane 100}
+    # EoMa's anti-shield is "secret", and the Era of Fours Moons has "insects"
+    {SXC_ENEMY_GUARD_CHANGE_ARMOR 10 14 9 secret 100}
+    {SXC_ENEMY_GUARD_CHANGE_ARMOR 10 14 9 insects 100}
+    # And this is just for players who mouse-over the hp to see what he's resistant to
+    {SXC_ENEMY_GUARD_CHANGE_ARMOR 10 14 9 poke 100}
+
+    # Copy the unit data so that the sxc_spooky_spawnkilled_zombies trap can spawn clones
+    [store_unit]
+      [filter]
+        id=Boss_10
+      [/filter]
+      variable=sxc_clone_of_pokey
+    [/store_unit]
 
     {SXC_ENEMY_LEADER_ADD_ABILITY 6 ({ABILITY_SXC_REGENERATESX 100})}
     {SXC_ENEMY_LEADER_CHANGE_ATTACK 6 2 (
@@ -492,6 +505,28 @@ Unfortunately the only way to get out alive is to kill all enemy leaders. Will y
     [/message]
   [/event]
 
+  # The map design is that the zombies are strong enough that the players have to run at the start,
+  # but it's possible to build a zombie-killer at the start, even without Ageless era (choose a
+  # character for which level 1 is the max, then buy 95% impact res and arcane berserk).
+  # Credit rpetiger for working that out, but in this map that calls for an event... lol...
+  [event]
+    name=prestart
+    {VARIABLE sxc_spooky_spawnkilled_zombies 0}
+  [/event]
+
+  [event]
+    name=die
+    first_time_only=no
+    [filter]
+      role=boss
+      side=9
+      type="Soulless"
+      x=1-7,8-13
+      y=27-40,35-40
+    [/filter]
+    {VARIABLE_OP sxc_spooky_spawnkilled_zombies add 1}
+  [/event]
+
 # comment: another mean trick... but lol...
 
   [event]
@@ -520,7 +555,7 @@ Unfortunately the only way to get out alive is to kill all enemy leaders. Will y
     [/message]
   [/event]
 
-# comment: an extremely crule trick... but lol...
+# comment: an extremely cruel trick... but lol...
 
   [event]
     name=moveto
@@ -546,6 +581,55 @@ Unfortunately the only way to get out alive is to kill all enemy leaders. Will y
       speaker=unit
       message=_ "Huh? ... Oh no! I heard something again ..."
     [/message]
+
+    [if]
+      {SXC_CMP sxc_spooky_spawnkilled_zombies greater_than 7}
+      [then]
+        [message]
+          speaker=unit
+          # po: Deliberately a fourth-wall-breaking comment. This is an easter egg that's only meant
+          # po: to trigger if the players are sequence-breaking.
+          message=_ "Wait, why are we worried about what made that noise? We're killing these zombies before they even get out of the south-west corner of the map, we've already won!"
+        [/message]
+
+        {VARIABLE sxc_clone_of_pokey.name ( _ "Clone of Pokey") }
+        {CLEAR_VARIABLE sxc_clone_of_pokey.ai_special}
+        {VARIABLE sxc_clone_of_pokey.status.guardian "no"}
+        # leave sxc_clone_of_pokey.role as "big_boss", they all have to be killed
+
+        [store_unit]
+          [filter]
+            type="Soulless"
+            role=boss
+            side=9
+          [/filter]
+          variable=zombie_bosses
+        [/store_unit]
+        [foreach]
+          array=zombie_bosses
+          [do]
+            {VARIABLE sxc_clone_of_pokey.x $this_item.x}
+            {VARIABLE sxc_clone_of_pokey.y $this_item.y}
+            {VARIABLE sxc_clone_of_pokey.hitpoints $this_item.hitpoints}
+            {VARIABLE sxc_clone_of_pokey.max_hitpoints $this_item.max_hitpoints}
+            {VARIABLE sxc_clone_of_pokey.moves 5}
+            {VARIABLE sxc_clone_of_pokey.max_moves 5}
+            {VARIABLE sxc_clone_of_pokey.id $this_item.id}
+            {VARIABLE sxc_clone_of_pokey.underlying_id $this_item.underlying_id}
+            [unstore_unit]
+              variable=sxc_clone_of_pokey
+            [/unstore_unit]
+          [/do]
+        [/foreach]
+        {CLEAR_VARIABLE zombie_bosses}
+        [message]
+          speaker=$sxc_clone_of_pokey.id
+          message=_ "Prepare to be poked, poked, poked, poked, poked, poked, poked, poked, poked, and poked some more."
+        [/message]
+
+        # obligatory lol comment... lol...
+      [/then]
+    [/if]
   [/event]
 
 # comment: a common button press event...


### PR DESCRIPTION
The bug being that it's possible to kill the zombies at the start, if you
figure out an exact loophole-exploiting build. By "fix with Pokey", I mean
that, if more than 8 zombies are spawnkilled south-west of the wall in the
south-west corner, the third wave of zombies is replaced with 800hp clones of
the Master of Poking.

With Ageless Era's overpowered characters, I can imagine that a few zombies
could be killed at the start, but killing 8 in normal play seems improbable.

Something is breaking Pokey's ellipse, and I don't see why it worked before.
It's broken for Pokey himself, as well as the clones, because the engine sees
that he has canrecruit=yes, so tries to find a hero-leader ellipse.  Changed
his crown and halo to expendable-leader instead.  The canrecruit setting itself
is done by SXC, seeing as he's a big_boss.