### PR TITLE
SXC Update the list of plagues and drains for Ageless 4.20

### DIFF
--- a/macros/SXCmacros.cfg
+++ b/macros/SXCmacros.cfg
@@ -1058,7 +1058,7 @@
 #define SXC_TRAIT_EFFECTS
   [effect]
     apply_to=attack
-    remove_specials=stones,AE_mag_id_sculpts,plague,plague(EOM_Bloodborn),plague(bliinfec),plague(bliseed),plague(blipara),plague(ifimp),plague(hivgnat),plague(Slavsav),plague(Slave),plague(AE_agl_yokai_Swarm_Spawn),plague(AE_mrc_Blight_Infected),plague(AE_efm_pygmies_Lizard),plague(AE_myh_Bloodborn),swarm,suicide,spores,latch,curse,BM New Zombie,BM Young Vampire,BM_cursed,plague(BM Bloodborn),CE_cursed,drains,circle,BM soulbind,
+    remove_specials=stones,AE_mag_id_sculpts,plague,plague(EOM_Bloodborn),plague(bliinfec),plague(bliseed),plague(blipara),plague(ifimp),plague(hivgnat),plague(Slavsav),plague(Slave),swarm,suicide,spores,latch,curse,BM New Zombie,BM Young Vampire,BM_cursed,plague(BM Bloodborn),CE_cursed,drains,circle,BM soulbind,plague(AE_agl_yokai_Swarm_Spawn),plague(AE_efm_pygmies_Lizard),plague(AE_efm_pygmies_Toad),plague(AE_ele_Skeletal_Corpse),plague(AE_ext_monsters_Baby_Mudcrawler),plague(AE_mrc_Blight_Infected),plague(AE_mrc_Blight_Parasite),plague(AE_mrc_hive_Gnat),plague(AE_mrc_infernai_Imp),plague(AE_mrc_slavers_Slave),plague(AE_myh_Bloodborn),plague(AE_rhy_de_Spiderling),AE_ele_fallen_drain0.125,AE_ele_fallen_drain0.15,AE_ele_fallen_drain0.2,AE_ele_fallen_drain0.20,AE_ele_fallen_drain0.25,AE_ele_fallen_drain0.33,AE_ele_fallen_drain0.40,AE_ele_fallen_drain0.50,
   [/effect]
   [effect]
     apply_to=remove_ability


### PR DESCRIPTION
I rearranged the previously-known-to-SXC list so that all the AE ones
are in alphabetical order, none have been removed (and all of them are
used in AE 4.20).

Remove the Fallen's consume (drains) special.