### PR TITLE
SXC Support more than 4 ai sides

### DIFF
--- a/macros/SXC_items.cfg
+++ b/macros/SXC_items.cfg
@@ -3,7 +3,9 @@
     name=moveto
     first_time_only=no
     [filter]
-      side=1,2,3,4,5
+      [filter_side]
+        team_name=Heroes
+      [/filter_side]
       canrecruit=yes
     [/filter]
     {VARIABLE item_found no}

--- a/macros/SXCmacros.cfg
+++ b/macros/SXCmacros.cfg
@@ -367,15 +367,15 @@
     name=advance
     first_time_only=no
     [filter]
-      team_name=Heroes
+      [filter_side]
+        team_name=Heroes
+      [/filter_side]
       canrecruit=yes
       x,y=$x1,$y1
     [/filter]
     [store_unit]
       [filter]
-        team_name=Heroes
         x,y=$x1,$y1
-        canrecruit=yes
       [/filter]
       variable=preadvance
     [/store_unit]
@@ -389,13 +389,13 @@
     first_time_only=no
     [filter]
       x,y=$x1,$y1
-      team_name=Heroes
+      [filter_side]
+        team_name=Heroes
+      [/filter_side]
       canrecruit=yes
     [/filter]
     [store_unit]
       [filter]
-        team_name=Heroes
-        canrecruit=yes
         x,y=$x1,$y1
       [/filter]
       variable=postadvance
@@ -1015,7 +1015,7 @@
 #define SXC_TEST_PLAYER_SIDE_2 SIDE GOLD ADJUSTMENT
   [side]
     side={SIDE}
-    team_name=1
+    team_name=Heroes
     canrecruit=yes
     controller=human
     income=-2
@@ -1655,7 +1655,9 @@
     name=moveto
     first_time_only=no
     [filter]
-      side=1,2,3,4,5
+      [filter_side]
+        team_name=Heroes
+      [/filter_side]
       x=$shopxs
       y=$shopys
       canrecruit=yes
@@ -5698,7 +5700,9 @@ sell them. Sell price is 60% of normal price.</span>
     name=die
     first_time_only=no
     [filter_second]
-      side=1,2,3,4,5
+      [filter_side]
+        team_name=Heroes
+      [/filter_side]
     [/filter_second]
     [store_unit]
       variable=victim
@@ -5973,7 +5977,9 @@ sell them. Sell price is 60% of normal price.</span>
     name=moveto
     first_time_only=yes
     [filter]
-      side=1,2,3,4,5
+      [filter_side]
+        team_name=Heroes
+      [/filter_side]
     [/filter]
     [message]
       speaker=narrator
@@ -6163,17 +6169,9 @@ of good luck.</span>"}
       id=SXC_Active_Difficulty
       description="$difficulty_text|"
       [command]
-        [message]
-          speaker=narrator
-          message="Brutal: $brutal|
-Earned gold: $income_$side_number||
-Recruits alive side 6: $recruits_6|
-Recruits alive side 7: $recruits_7|
-Recruits alive side 8: $recruits_8|
-Recruits alive side 9: $recruits_9|"
-          side_for=$side_number
-          image=wesnoth-icon.png
-        [/message]
+        [fire_event]
+          name=sxc_show_difficulty
+        [/fire_event]
       [/command]
     [/set_menu_item]
     [if]
@@ -6241,6 +6239,30 @@ $maptext|"
       [/then]
     [/if]
   [/event]
+
+  [event]
+    name=sxc_show_difficulty
+    first_time_only=no
+    {VARIABLE summary (_ "Brutal: $brutal|")}
+    [store_side]
+      team_name=Enemies
+    [/store_side]
+    [foreach]
+      array=side
+      [do]
+        {VARIABLE number $this_item.side|}
+        {VARIABLE summary ($summary| + "
+" + _ "Recruits alive side $number|: $recruits_$number||")}
+      [/do]
+    [/foreach]
+    [message]
+      speaker=narrator
+      message=$summary
+      side_for=$side_number
+      image=wesnoth-icon.png
+    [/message]
+    {CLEAR_VARIABLE summary}
+  [/event]
 #enddef
 
 #define SXC_DEATH_MESSAGES
@@ -6248,7 +6270,9 @@ $maptext|"
     name=die
     first_time_only=no
     [filter]
-      side=1,2,3,4,5
+      [filter_side]
+        team_name=Heroes
+      [/filter_side]
       canrecruit=yes
     [/filter]
     [store_unit]
@@ -6543,7 +6567,9 @@ $maptext|"
     [store_unit]
       [filter]
         x,y=$x1,$y1
-        side=6,7,8,9
+        [filter_side]
+          team_name=Enemies
+        [/filter_side]
       [/filter]
       variable=creep
     [/store_unit]
@@ -6572,7 +6598,9 @@ $maptext|"
       [then]
         [filter]
           x,y=$x1,$y1
-          side=6,7,8,9
+          [filter_side]
+            team_name=Enemies
+          [/filter_side]
         [/filter]
         {SXC_ENEMY_UPGRADE_WEAPON 8 3}
         [object]
@@ -6620,7 +6648,9 @@ $maptext|"
       [then]
         [filter]
           x,y=$x1,$y1
-          side=6,7,8,9
+          [filter_side]
+            team_name=Enemies
+          [/filter_side]
         [/filter]
         {SXC_ENEMY_UPGRADE_WEAPON 8 3}
         [object]
@@ -6668,7 +6698,9 @@ $maptext|"
       [then]
         [filter]
           x,y=$x1,$y1
-          side=6,7,8,9
+          [filter_side]
+            team_name=Enemies
+          [/filter_side]
         [/filter]
         {SXC_ENEMY_UPGRADE_WEAPON 8 3}
         [object]
@@ -6716,7 +6748,9 @@ $maptext|"
       [then]
         [filter]
           x,y=$x1,$y1
-          side=6,7,8,9
+          [filter_side]
+            team_name=Enemies
+          [/filter_side]
         [/filter]
         {SXC_ENEMY_UPGRADE_WEAPON 8 3}
         [object]
@@ -6764,7 +6798,9 @@ $maptext|"
       [then]
         [filter]
           x,y=$x1,$y1
-          side=6,7,8,9
+          [filter_side]
+            team_name=Enemies
+          [/filter_side]
         [/filter]
         {SXC_ENEMY_UPGRADE_WEAPON 8 3}
         [object]
@@ -6812,7 +6848,9 @@ $maptext|"
       [then]
         [filter]
           x,y=$x1,$y1
-          side=6,7,8,9
+          [filter_side]
+            team_name=Enemies
+          [/filter_side]
         [/filter]
         {SXC_ENEMY_UPGRADE_WEAPON 8 3}
         [object]
@@ -6860,7 +6898,9 @@ $maptext|"
       [then]
         [filter]
           x,y=$x1,$y1
-          side=6,7,8,9
+          [filter_side]
+            team_name=Enemies
+          [/filter_side]
         [/filter]
         {SXC_ENEMY_UPGRADE_WEAPON 7 3}
         [object]
@@ -6908,7 +6948,9 @@ $maptext|"
       [then]
         [filter]
           x,y=$x1,$y1
-          side=6,7,8,9
+          [filter_side]
+            team_name=Enemies
+          [/filter_side]
         [/filter]
         {SXC_ENEMY_UPGRADE_WEAPON 7 3}
         [object]
@@ -6956,7 +6998,9 @@ $maptext|"
       [then]
         [filter]
           x,y=$x1,$y1
-          side=6,7,8,9
+          [filter_side]
+            team_name=Enemies
+          [/filter_side]
         [/filter]
         {SXC_ENEMY_UPGRADE_WEAPON 6 3}
         [object]
@@ -7004,7 +7048,9 @@ $maptext|"
       [then]
         [filter]
           x,y=$x1,$y1
-          side=6,7,8,9
+          [filter_side]
+            team_name=Enemies
+          [/filter_side]
         [/filter]
         {SXC_ENEMY_UPGRADE_WEAPON 6 3}
         [object]
@@ -7052,7 +7098,9 @@ $maptext|"
       [then]
         [filter]
           x,y=$x1,$y1
-          side=6,7,8,9
+          [filter_side]
+            team_name=Enemies
+          [/filter_side]
         [/filter]
         {SXC_ENEMY_UPGRADE_WEAPON 6 2}
         [object]
@@ -7100,7 +7148,9 @@ $maptext|"
       [then]
         [filter]
           x,y=$x1,$y1
-          side=6,7,8,9
+          [filter_side]
+            team_name=Enemies
+          [/filter_side]
         [/filter]
         {SXC_ENEMY_UPGRADE_WEAPON 5 2}
         [object]
@@ -7148,7 +7198,9 @@ $maptext|"
       [then]
         [filter]
           x,y=$x1,$y1
-          side=6,7,8,9
+          [filter_side]
+            team_name=Enemies
+          [/filter_side]
         [/filter]
         {SXC_ENEMY_UPGRADE_WEAPON 4 2}
         [object]
@@ -7196,7 +7248,9 @@ $maptext|"
       [then]
         [filter]
           x,y=$x1,$y1
-          side=6,7,8,9
+          [filter_side]
+            team_name=Enemies
+          [/filter_side]
         [/filter]
         {SXC_ENEMY_UPGRADE_WEAPON 4 2}
         [object]
@@ -7244,7 +7298,9 @@ $maptext|"
       [then]
         [filter]
           x,y=$x1,$y1
-          side=6,7,8,9
+          [filter_side]
+            team_name=Enemies
+          [/filter_side]
         [/filter]
         {SXC_ENEMY_UPGRADE_WEAPON 4 1}
         [object]
@@ -7274,7 +7330,9 @@ $maptext|"
       [then]
         [filter]
           x,y=$x1,$y1
-          side=6,7,8,9
+          [filter_side]
+            team_name=Enemies
+          [/filter_side]
         [/filter]
         {SXC_ENEMY_UPGRADE_WEAPON 4 1}
       [/then]
@@ -7509,7 +7567,9 @@ $maptext|"
 #define SXC_REDRAW_TERRAIN
   [redraw]
     clear_shroud=true
-    side=1,2,3,4,5
+    [filter_side]
+      team_name=Heroes
+    [/filter_side]
   [/redraw]
 #enddef
 

--- a/macros/SXCmacros.cfg
+++ b/macros/SXCmacros.cfg
@@ -264,6 +264,8 @@
   {VARIABLE cashstop_7 1000}
   {VARIABLE cashstop_8 1000}
   {VARIABLE cashstop_9 1000}
+  {VARIABLE cashstop_10 1000}
+  {VARIABLE cashstop_11 1000}
   {VARIABLE allow_shop_potions "no"}
   {VARIABLE allow_shop_blackp "no"}
   {VARIABLE allow_shop_bluep "no"}
@@ -361,6 +363,8 @@
   {VARIABLE recruits_7 0}
   {VARIABLE recruits_8 0}
   {VARIABLE recruits_9 0}
+  {VARIABLE recruits_10 0}
+  {VARIABLE recruits_11 0}
 
   {SXC_ARMORY_LIMIT_EVENT}
   [event]
@@ -7410,7 +7414,13 @@ $maptext|"
   [/event]
 #enddef
 
+# At the start of each turn, the players get bonus gold for each ai side whose leader is dead
 #define SXC_INCOME_BONUS B6 B7 B8 B9
+  {SXC_INCOME_BONUS_6 B6 B7 B8 B9 0 0}
+#enddef
+
+# A version of SXC_INCOME_BONUS for maps with up to 6 ai sides
+#define SXC_INCOME_BONUS_6 B6 B7 B8 B9 B10 B11
   [event]
     name=new turn
     first_time_only=no
@@ -7457,6 +7467,28 @@ $maptext|"
       [/not]
       [then]
         {VARIABLE_OP income_bonus add "{B9}"}
+      [/then]
+    [/if]
+    [if]
+      [not]
+        [have_unit]
+          side=10
+          role="big_boss"
+        [/have_unit]
+      [/not]
+      [then]
+        {VARIABLE_OP income_bonus add "{B10}"}
+      [/then]
+    [/if]
+    [if]
+      [not]
+        [have_unit]
+          side=11
+          role="big_boss"
+        [/have_unit]
+      [/not]
+      [then]
+        {VARIABLE_OP income_bonus add "{B11}"}
       [/then]
     [/if]
     [if]


### PR DESCRIPTION
Hardcoded support for 6 AI sides, incomplete support for an arbitrary number

It would be good to support an arbitrary number of AI sides, but that would
require a larger refactor of SXC. The parts that are already complete are in the
"incomplete support for arbitrary numbers of sides", whereas the parts in the
"hardcoded support" commit have simply been updated to fit the number of sides
in the WIP maps with ai10 and possibly ai11.

This requires Wesnoth 1.14. It will seem to work on 1.12.6 until someone saves
and reloads. Saving and reloading on 1.12.6 will reset the team names, and all
team_name based events will stop working.

Use team names "Heroes" and "Enemies" instead of 1,2,3,4,5 and 6,7,8,9.