### PR TITLE
SXC Ask "melee or ranged" in the player's language

### DIFF
--- a/macros/SXCmacros.cfg
+++ b/macros/SXCmacros.cfg
@@ -534,7 +534,7 @@
     {VARIABLE hide_ranged_$sxc_side no}
     {VARIABLE hide_melee_$sxc_side no}
     {VARIABLE terrains_left_$sxc_side 2}
-    {VARIABLE upgrades_range_$sxc_side "none"}
+    {VARIABLE sxc_attack_specialization_$sxc_side "none"}
     {VARIABLE mc_castle_$sxc_side 0}
     {VARIABLE mc_cave_$sxc_side 0}
     {VARIABLE mc_deep_water_$sxc_side 0}
@@ -1931,45 +1931,47 @@ until you will leave selected shop section.</span>
           {VARIABLE str_price_3ranged $str_price_ranged}
           {VARIABLE_OP str_price_3ranged multiply 3}
           {VARIABLE_OP str_price_3ranged add 15}
-          [if]
-            {SXC_CMP upgrades_range_$side_number equals "melee"}
-            [then]
-              {VARIABLE_OP str_price_ranged multiply 2}
-              {VARIABLE_OP str_price_3ranged multiply 2}
-              {VARIABLE dmg_price_ranged 40}
-              {VARIABLE dmg_price_5ranged 180}
-            [/then]
+          {VARIABLE choose_range ""}
+          [switch]
+            variable=sxc_attack_specialization_$side_number
+            [case]
+              value="melee"
+                {VARIABLE dmg_price_melee 20}
+                {VARIABLE dmg_price_5melee 90}
+                {VARIABLE_OP str_price_ranged multiply 2}
+                {VARIABLE_OP str_price_3ranged multiply 2}
+                {VARIABLE dmg_price_ranged 40}
+                {VARIABLE dmg_price_5ranged 180}
+            [/case]
+            [case]
+              value="ranged"
+                {VARIABLE_OP str_price_melee multiply 2}
+                {VARIABLE_OP str_price_3melee multiply 2}
+                {VARIABLE dmg_price_melee 40}
+                {VARIABLE dmg_price_5melee 180}
+                {VARIABLE dmg_price_ranged 20}
+                {VARIABLE dmg_price_5ranged 90}
+            [/case]
             [else]
-              {VARIABLE dmg_price_ranged 20}
-              {VARIABLE dmg_price_5ranged 90}
-            [/else]
-          [/if]
-          [if]
-            {SXC_CMP upgrades_range_$side_number equals "ranged"}
-            [then]
-              {VARIABLE_OP str_price_melee multiply 2}
-              {VARIABLE_OP str_price_3melee multiply 2}
-              {VARIABLE dmg_price_melee 40}
-              {VARIABLE dmg_price_5melee 180}
-            [/then]
-            [else]
-              {VARIABLE dmg_price_melee 20}
-              {VARIABLE dmg_price_5melee 90}
-            [/else]
-          [/if]
-          [if]
-            {SXC_CMP upgrades_range_$side_number equals "none"}
-            [then]
-              {VARIABLE choose_range "<span color='#FF2020' weight='bold'>Before you will be able to buy damage and strikes training,
-you must choose which range training you will focus on.
-Other range will become much harder to improve and it will
-cause that it will cost double price of the selected range.</span>
+              # sxc_attack_specialization_$side_number is "none"
+
+              # The lua code does a rough translation of "Melee or ranged" using core Wesnoth's translated strings
+              [lua]
+                  code=<<
+                      local _ = wesnoth.textdomain "wesnoth"
+                      local empty_str = ""
+                      local ranges = { _ "melee", _ "ranged" }
+                      wesnoth.set_variable ("sxc_l10n_header", wesnoth.format_disjunct_list(empty_str, ranges))
+                  >>
+              [/lua]
+              {VARIABLE choose_range "<span color='#FF2020' weight='bold'>$sxc_l10n_header</span>
+Before you will be able to buy damage and strikes training, you must choose
+which range training you will focus on.  The other range will be much more
+expensive to improve, it will cost the double price of the selected range.
 "}
-            [/then]
-            [else]
-              {VARIABLE choose_range ""}
+              {CLEAR_VARIABLE sxc_l10n_header}
             [/else]
-          [/if]
+          [/switch]
           [message]
             speaker=narrator
             message="<span color='#40C020' size='x-large' weight='bold'>Enhancements</span>
@@ -1988,7 +1990,7 @@ $choose_range|<span color='#E0E018'>Gold: $gold|</span>
               [show_if]
                 {SXC_CMP hide_melee_$side_number equals no}
                 {SXC_CMP hide_ranged_$side_number equals no}
-                {SXC_CMP upgrades_range_$side_number not_equals "none"}
+                {SXC_CMP sxc_attack_specialization_$side_number not_equals "none"}
               [/show_if]
               message={MENU_IMG_TXT "icons/damage-melee.png" "<span color='#FF9060'>Hide melee upgrades</span>"}
               [command]
@@ -1998,7 +2000,7 @@ $choose_range|<span color='#E0E018'>Gold: $gold|</span>
             [option]
               [show_if]
                 {SXC_CMP hide_melee_$side_number equals yes}
-                {SXC_CMP upgrades_range_$side_number not_equals "none"}
+                {SXC_CMP sxc_attack_specialization_$side_number not_equals "none"}
               [/show_if]
               message={MENU_IMG_TXT "icons/damage-melee.png" "<span color='#60C060'>Show melee upgrades</span>"}
               [command]
@@ -2007,11 +2009,11 @@ $choose_range|<span color='#E0E018'>Gold: $gold|</span>
             [/option]
             [option]
               [show_if]
-                {SXC_CMP upgrades_range_$side_number equals "none"}
+                {SXC_CMP sxc_attack_specialization_$side_number equals "none"}
               [/show_if]
-              message={MENU_IMG_TXT "icons/damage-melee.png" "<span color='#FF2020'>I will focus on melee training</span>"}
+              message={MENU_IMG_TXT "icons/damage-melee.png" ("<span color='#FF2020'>" + _ "melee" + ":</span> I will focus on melee training")}
               [command]
-                {VARIABLE upgrades_range_$side_number "melee"}
+                {VARIABLE sxc_attack_specialization_$side_number "melee"}
               [/command]
             [/option]
             [option]
@@ -2041,7 +2043,7 @@ $choose_range|<span color='#E0E018'>Gold: $gold|</span>
             [option]
               [show_if]
                 {SXC_CMP hide_melee_$side_number equals no}
-                {SXC_CMP upgrades_range_$side_number not_equals "none"}
+                {SXC_CMP sxc_attack_specialization_$side_number not_equals "none"}
               [/show_if]
               message={MENU_IMG_TXT "icons/damage-melee.png" "<span color='#80FF80' >$dmg_price_melee| gold: +1 Melee Damage</span>"}
               [command]
@@ -2071,7 +2073,7 @@ $choose_range|<span color='#E0E018'>Gold: $gold|</span>
             [option]
               [show_if]
                 {SXC_CMP hide_melee_$side_number equals no}
-                {SXC_CMP upgrades_range_$side_number not_equals "none"}
+                {SXC_CMP sxc_attack_specialization_$side_number not_equals "none"}
               [/show_if]
               message={MENU_IMG_TXT "icons/damage-melee.png" "<span color='#80FF80'>$dmg_price_5melee| gold: +5 Melee Damage</span>"}
               [command]
@@ -2126,7 +2128,7 @@ $choose_range|<span color='#E0E018'>Gold: $gold|</span>
               [show_if]
                 {SXC_CMP hide_melee_$side_number equals no}
                 {SXC_CMP melee_strikes_$side_number less_than 12}
-                {SXC_CMP upgrades_range_$side_number not_equals "none"}
+                {SXC_CMP sxc_attack_specialization_$side_number not_equals "none"}
               [/show_if]
               message={MENU_IMG_TXT "icons/strikes-melee.png" "<span color='#80FF80'>$str_price_melee| gold: +1 Melee Strikes</span>"}
               [command]
@@ -2157,7 +2159,7 @@ $choose_range|<span color='#E0E018'>Gold: $gold|</span>
               [show_if]
                 {SXC_CMP hide_melee_$side_number equals no}
                 {SXC_CMP melee_strikes_$side_number less_than 10}
-                {SXC_CMP upgrades_range_$side_number not_equals "none"}
+                {SXC_CMP sxc_attack_specialization_$side_number not_equals "none"}
               [/show_if]
               message={MENU_IMG_TXT "icons/strikes-melee.png" "<span color='#80FF80'>$str_price_3melee| gold: +3 Melee Strikes</span>"}
               [command]
@@ -2188,7 +2190,7 @@ $choose_range|<span color='#E0E018'>Gold: $gold|</span>
               [show_if]
                 {SXC_CMP hide_melee_$side_number equals no}
                 {SXC_CMP hide_ranged_$side_number equals no}
-                {SXC_CMP upgrades_range_$side_number not_equals "none"}
+                {SXC_CMP sxc_attack_specialization_$side_number not_equals "none"}
               [/show_if]
               message={MENU_IMG_TXT "icons/damage-ranged.png" "<span color='#FF9060'>Hide ranged upgrades</span>"}
               [command]
@@ -2198,7 +2200,7 @@ $choose_range|<span color='#E0E018'>Gold: $gold|</span>
             [option]
               [show_if]
                 {SXC_CMP hide_ranged_$side_number equals yes}
-                {SXC_CMP upgrades_range_$side_number not_equals "none"}
+                {SXC_CMP sxc_attack_specialization_$side_number not_equals "none"}
               [/show_if]
               message={MENU_IMG_TXT "icons/damage-ranged.png" "<span color='#60C060'>Show ranged upgrades</span>"}
               [command]
@@ -2207,11 +2209,11 @@ $choose_range|<span color='#E0E018'>Gold: $gold|</span>
             [/option]
             [option]
               [show_if]
-                {SXC_CMP upgrades_range_$side_number equals "none"}
+                {SXC_CMP sxc_attack_specialization_$side_number equals "none"}
               [/show_if]
-              message={MENU_IMG_TXT "icons/damage-ranged.png" "<span color='#FF2020'>I will focus on ranged training</span>"}
+              message={MENU_IMG_TXT "icons/damage-ranged.png" ("<span color='#FF2020'>" + _ "ranged" + ":</span> I will focus on ranged training")}
               [command]
-                {VARIABLE upgrades_range_$side_number "ranged"}
+                {VARIABLE sxc_attack_specialization_$side_number "ranged"}
               [/command]
             [/option]
             [option]
@@ -2241,7 +2243,7 @@ $choose_range|<span color='#E0E018'>Gold: $gold|</span>
             [option]
               [show_if]
                 {SXC_CMP hide_ranged_$side_number equals no}
-                {SXC_CMP upgrades_range_$side_number not_equals "none"}
+                {SXC_CMP sxc_attack_specialization_$side_number not_equals "none"}
               [/show_if]
               message={MENU_IMG_TXT "icons/damage-ranged.png" "<span color='#80FF80'>$dmg_price_ranged| gold: +1 Ranged Damage</span>"}
               [command]
@@ -2271,7 +2273,7 @@ $choose_range|<span color='#E0E018'>Gold: $gold|</span>
             [option]
               [show_if]
                 {SXC_CMP hide_ranged_$side_number equals no}
-                {SXC_CMP upgrades_range_$side_number not_equals "none"}
+                {SXC_CMP sxc_attack_specialization_$side_number not_equals "none"}
               [/show_if]
               message={MENU_IMG_TXT "icons/damage-ranged.png" "<span color='#80FF80'>$dmg_price_5ranged| gold: +5 Ranged Damage</span>"}
               [command]
@@ -2326,7 +2328,7 @@ $choose_range|<span color='#E0E018'>Gold: $gold|</span>
               [show_if]
                 {SXC_CMP hide_ranged_$side_number equals no}
                 {SXC_CMP ranged_strikes_$side_number less_than 12}
-                {SXC_CMP upgrades_range_$side_number not_equals "none"}
+                {SXC_CMP sxc_attack_specialization_$side_number not_equals "none"}
               [/show_if]
               message={MENU_IMG_TXT "icons/strikes-ranged.png" "<span color='#80FF80'>$str_price_ranged| gold: +1 Ranged Strikes</span>"}
               [command]
@@ -2357,7 +2359,7 @@ $choose_range|<span color='#E0E018'>Gold: $gold|</span>
               [show_if]
                 {SXC_CMP hide_ranged_$side_number equals no}
                 {SXC_CMP ranged_strikes_$side_number less_than 10}
-                {SXC_CMP upgrades_range_$side_number not_equals "none"}
+                {SXC_CMP sxc_attack_specialization_$side_number not_equals "none"}
               [/show_if]
               message={MENU_IMG_TXT "icons/strikes-ranged.png" "<span color='#80FF80'>$str_price_3ranged| gold: +3 Ranged Strikes</span>"}
               [command]


### PR DESCRIPTION
Includes a general code cleanup for the choice of melee or ranged, and
renames upgrades_range_ to sxc_attack_specialization_.

The multilingual support is a bit hacky, but better than not having
it. Thanks to CelticMinstrel for the code that this was based on.