### PR TITLE
SXC Update AI settings to Wesnoth 1.14

### DIFF
--- a/macros/SXC_unit_macros.cfg
+++ b/macros/SXC_unit_macros.cfg
@@ -188,8 +188,7 @@
       grouping=no
       leader_aggression=-10.0
       passive_leader=no
-      recruitment_ignore_bad_combat=yes
-      recruitment_ignore_bad_movement=yes
+      recruitment_diversity=3.0
       recruitment_pattern=""
       simple_targeting=yes
     [/ai]

--- a/macros/SXCmacros.cfg
+++ b/macros/SXCmacros.cfg
@@ -988,11 +988,20 @@
     {ADJUSTMENT}
     [ai]
       passive_leader=yes
-      #      ai_algorithm=default
       village_value=-34.8
       aggression=0.0
       caution=1.0
-      number_of_possible_recruits_to_force_recruit=0.0
+      [aspect]
+        id=recruitment_instructions
+        [facet]
+          [value]
+            [recruit]
+              importance=1
+              number=0
+            [/recruit]
+          [/value]
+        [/facet]
+      [/aspect]
     [/ai]
     [modifications]
       [trait]


### PR DESCRIPTION
Tell the AI to recruit a diverse set of units, and fix these warnings:
* aspect with id=[number_of_possible_recruits_to_force_recruit] lacks default config facet!
* aspect with id=[recruitment_ignore_bad_combat] lacks default config facet!
* aspect with id=[recruitment_ignore_bad_movement] lacks default config facet!