### PR TITLE
SXC Spooky Forest in revive mode, respawn near a different shop

### DIFF
--- a/macros/SXCmacros.cfg
+++ b/macros/SXCmacros.cfg
@@ -577,7 +577,15 @@
     {VARIABLE impact_boost_$sxc_side 0}
     {VARIABLE pierce_boost_$sxc_side 0}
     {VARIABLE defense_boost_$sxc_side 0}
-    {VARIABLE revive "no"}
+    {VARIABLE sxc_revive_mode "no"}
+    [set_variables]
+      name=sxc_revive_location
+      mode=replace
+      [value]
+        x=999
+        y=999
+      [/value]
+    [/set_variables]
     {SXC_CHECK_ARMOR_TOTAL $sxc_side}
     {SXC_UNIT_MOVEMENTS_RESTORE $sxc_side}
     {SXC_DISALLOW_RECRUITS $sxc_side}
@@ -6043,7 +6051,7 @@ upgrades it had at the moment it was killed.</span>"}
           [/print]
           {VARIABLE difficulty 25}
           {VARIABLE difficulty_text "Difficulty: ROOKIE"}
-          {VARIABLE revive "yes"}
+          {VARIABLE sxc_revive_mode "yes"}
         [/command]
       [/option]
       [option]
@@ -6190,7 +6198,7 @@ of good luck.</span>"}
       [/command]
     [/set_menu_item]
     [if]
-      {SXC_CMP revive boolean_equals yes}
+      {SXC_CMP sxc_revive_mode boolean_equals yes}
       [then]
         {VARIABLE helptext "<span color='#40FF40' size='large'>Help for beginners</span>
 To show this help text any time later, right click and choose 'SXCollection Help'
@@ -6280,6 +6288,20 @@ $maptext|"
   [/event]
 #enddef
 
+# When revive mode is on, the players will normally respawn at their starting locations. For Spooky
+# Forest, the start is meant to be inaccessible after the first turn or two, and this allows the
+# respawn to happen near the second shop instead.
+#define SXC_SET_REVIVE_LOCATION X Y
+  [set_variables]
+    name=sxc_revive_location
+    mode=replace
+    [value]
+      x={X}
+      y={Y}
+    [/value]
+  [/set_variables]
+#enddef
+
 #define SXC_DEATH_MESSAGES
   [event]
     name=die
@@ -6298,7 +6320,7 @@ $maptext|"
       variable=dying_friend
     [/store_unit]
     [if]
-      {SXC_CMP revive boolean_equals yes}
+      {SXC_CMP sxc_revive_mode boolean_equals yes}
       [then]
         [set_variables]
           name=death_texts
@@ -6327,24 +6349,38 @@ $maptext|"
       variable=gold_die
     [/store_gold]
     [if]
-      {SXC_CMP revive boolean_equals yes}
+      {SXC_CMP sxc_revive_mode boolean_equals yes}
       [then]
-        {VARIABLE deads $dead.length}
+        {VARIABLE deads $sxc_revive_dead.length}
         [store_unit]
           [filter]
             x,y=$x1,$y1
             canrecruit=yes
           [/filter]
-          variable=dead[$deads|]
+          variable=sxc_revive_dead[$deads|]
         [/store_unit]
-        [store_starting_location]
-          side=$dying_friend.side
-          variable=revive_location
-        [/store_starting_location]
-        {VARIABLE dead[$deads|].hitpoints 1}
-        {VARIABLE dead[$deads|].x $revive_location.x}
-        {VARIABLE dead[$deads|].y $revive_location.y}
-        {VARIABLE dead[$deads|].variables.gold $gold_die}
+        [if]
+          [have_location]
+            x=$sxc_revive_location.x
+            x=$sxc_revive_location.y
+          [/have_location]
+          [then]
+            [set_variables]
+              name=revive_location
+              to_variable=sxc_revive_location
+            [/set_variables]
+          [/then]
+          [else]
+            [store_starting_location]
+              side=$dying_friend.side
+              variable=revive_location
+            [/store_starting_location]
+          [/else]
+        [/if]
+        {VARIABLE sxc_revive_dead[$deads|].hitpoints 1}
+        {VARIABLE sxc_revive_dead[$deads|].x $revive_location.x}
+        {VARIABLE sxc_revive_dead[$deads|].y $revive_location.y}
+        {VARIABLE sxc_revive_dead[$deads|].variables.gold $gold_die}
         {CLEAR_VARIABLE deads}
         {CLEAR_VARIABLE revive_location}
       [/then]
@@ -6498,24 +6534,25 @@ $maptext|"
    [event]
     name=new turn
     first_time_only=no
-    {FOREACH dead i}
+    {FOREACH sxc_revive_dead i}
       [store_gold]
-        side=$dead[$i|].side
+        side=$sxc_revive_dead[$i|].side
         variable=side_gold
       [/store_gold]
       [gold]
-        side=$dead[$i|].side
+        side=$sxc_revive_dead[$i|].side
         amount=-$side_gold
       [/gold]
       [gold]
-        side=$dead[$i|].side
-        amount=$dead[$i|].variables.gold
+        side=$sxc_revive_dead[$i|].side
+        amount=$sxc_revive_dead[$i|].variables.gold
       [/gold]
       [unstore_unit]
-        variable=dead[$i|]
+        variable=sxc_revive_dead[$i|]
         find_vacant=yes
       [/unstore_unit]
       {CLEAR_VARIABLE side_gold}
+      {SXC_REDRAW_TERRAIN}
     {NEXT i}
     {CLEAR_VARIABLE dead}
   [/event]

--- a/scen_new/SXC_SpoOky_Forest.cfg
+++ b/scen_new/SXC_SpoOky_Forest.cfg
@@ -503,6 +503,9 @@ Unfortunately the only way to get out alive is to kill all enemy leaders. Will y
       side=5
       message=_ "They are coming this way! Let's go into the forest! ... Quickly!"
     [/message]
+
+    # In revive mode, start players half-way to the second shop
+    {SXC_SET_REVIVE_LOCATION 17 23}
   [/event]
 
   # The map design is that the zombies are strong enough that the players have to run at the start,
@@ -553,6 +556,9 @@ Unfortunately the only way to get out alive is to kill all enemy leaders. Will y
       speaker=unit
       message=_ "Huh? ... I think i heard something ..."
     [/message]
+
+    # Move the respawn location to this shop
+    {SXC_SET_REVIVE_LOCATION 33 3}
   [/event]
 
 # comment: an extremely cruel trick... but lol...
@@ -584,6 +590,11 @@ Unfortunately the only way to get out alive is to kill all enemy leaders. Will y
 
     [if]
       {SXC_CMP sxc_spooky_spawnkilled_zombies greater_than 7}
+      [not]
+        # In revive mode, players may kill zombies near the start without deliberately
+        # sequence-breaking, don't hit them with the anti-cheat Pokies.
+        {SXC_CMP sxc_revive_mode boolean_equals yes}
+      [/not]
       [then]
         [message]
           speaker=unit


### PR DESCRIPTION
Implement the feature for moving the respawn point in SXCmacros, and
rename the "revive" and "dead" variables to "sxc_revive_mode" and
"sxc_revive_dead" respectively.

When someone respawns, recalculate the fog and shroud at the start of
player 1's turn.

Don't trigger Spooky Forest's clones-of-Pokey in revive mode. It
didn't happen in the game that prompted this commit, but revive mode
players might kill zombies at the start without working out how to
do the squence-break.