### PR TITLE
SXC Use [modify_unit] for adding traits, and refactor the recruit-buffing code (fixes #54)

### DIFF
--- a/macros/SXCmacros.cfg
+++ b/macros/SXCmacros.cfg
@@ -4036,31 +4036,15 @@ resistances and resistances over 50% are not affected.</span>"}
                       amount=-100
                       side=$side_number
                     [/gold]
-                    [object]
-                      silent=yes
-                      duration=forever
-                      [effect]
-                        apply_to="fearless"
-                      [/effect]
-                    [/object]
-                    [store_unit]
+                    [modify_unit]
                       [filter]
                         side=$side_number
                         x,y=$x1,$y1
                         canrecruit=yes
                       [/filter]
-                      variable=trait_fearless
-                    [/store_unit]
-                    {VARIABLE new_trait $trait_fearless.modifications.trait.length}
-                    {VARIABLE trait_fearless.modifications.trait[$new_trait|].id ("fearless")}
-                    {VARIABLE trait_fearless.modifications.trait[$new_trait|].male_name (_ "fearless")}
-                    {VARIABLE trait_fearless.modifications.trait[$new_trait|].female_name (_ "female^fearless")}
-                    {VARIABLE trait_fearless.modifications.trait[$new_trait|].description (_ "Fights normally during unfavorable times of day/night")}
-                    [unstore_unit]
-                      variable=trait_fearless
-                    [/unstore_unit]
+                      {TRAIT_FEARLESS}
+                    [/modify_unit]
                     {VARIABLE_OP abilities_$side_number add 1}
-                    {CLEAR_VARIABLE trait_fearless}
                   [/then]
                 [/if]
               [/command]
@@ -6602,93 +6586,132 @@ $maptext|"
   [/event]
 #enddef
 
-#define SXC_ENEMY_UPGRADE_WEAPON DMG STR
+#define SXC_ENEMY_ADD_MELEE_WEAPON DMG STR
   {RANDOM 0..5}
   [switch]
     variable=random
     [case]
       value=0
-      {SXC_ENEMY_UPGRADE_WEAPON2 ARCANE {DMG} {STR}}
+      [object]
+        silent=yes
+        duration=forever
+        {SXC_ENEMY_WEAPON_ARCANE {DMG} {STR}}
+      [/object]
     [/case]
     [case]
       value=1
-      {SXC_ENEMY_UPGRADE_WEAPON2 BLADE {DMG} {STR}}
+      [object]
+        silent=yes
+        duration=forever
+        {SXC_ENEMY_WEAPON_BLADE {DMG} {STR}}
+      [/object]
     [/case]
     [case]
       value=2
-      {SXC_ENEMY_UPGRADE_WEAPON2 COLD {DMG} {STR}}
+      [object]
+        silent=yes
+        duration=forever
+        {SXC_ENEMY_WEAPON_COLD {DMG} {STR}}
+      [/object]
     [/case]
     [case]
       value=3
-      {SXC_ENEMY_UPGRADE_WEAPON2 FIRE {DMG} {STR}}
+      [object]
+        silent=yes
+        duration=forever
+        {SXC_ENEMY_WEAPON_FIRE {DMG} {STR}}
+      [/object]
     [/case]
     [case]
       value=4
-      {SXC_ENEMY_UPGRADE_WEAPON2 IMPACT {DMG} {STR}}
+      [object]
+        silent=yes
+        duration=forever
+        {SXC_ENEMY_WEAPON_IMPACT {DMG} {STR}}
+      [/object]
     [/case]
     [case]
       value=5
-      {SXC_ENEMY_UPGRADE_WEAPON2 PIERCE {DMG} {STR}}
+      [object]
+        silent=yes
+        duration=forever
+        {SXC_ENEMY_WEAPON_PIERCE {DMG} {STR}}
+      [/object]
     [/case]
   [/switch]
 #enddef
 
-#define SXC_ENEMY_UPGRADE_WEAPON2 TYPE DMG STR
-  [if]
-    {SXC_CMP creep_attacks_melee less_than 1}
-    [then]
+#define SXC_ENEMY_ADD_RANGED_WEAPON DMG STR
+  {RANDOM 0..5}
+  [switch]
+    variable=random
+    [case]
+      value=0
       [object]
         silent=yes
         duration=forever
-        {SXC_ENEMY_WEAPON_{TYPE} {DMG} {STR}}
+        {SXC_ENEMY_WEAPON_ARCANE_MISSILE {DMG} {STR}}
       [/object]
-    [/then]
-  [/if]
-  [if]
-    {SXC_CMP creep_attacks_ranged less_than 1}
-    [then]
+    [/case]
+    [case]
+      value=1
       [object]
         silent=yes
         duration=forever
-        {SXC_ENEMY_WEAPON_{TYPE}_MISSILE {DMG} {STR}}
+        {SXC_ENEMY_WEAPON_BLADE_MISSILE {DMG} {STR}}
       [/object]
-    [/then]
-  [/if]
+    [/case]
+    [case]
+      value=2
+      [object]
+        silent=yes
+        duration=forever
+        {SXC_ENEMY_WEAPON_COLD_MISSILE {DMG} {STR}}
+      [/object]
+    [/case]
+    [case]
+      value=3
+      [object]
+        silent=yes
+        duration=forever
+        {SXC_ENEMY_WEAPON_FIRE_MISSILE {DMG} {STR}}
+      [/object]
+    [/case]
+    [case]
+      value=4
+      [object]
+        silent=yes
+        duration=forever
+        {SXC_ENEMY_WEAPON_IMPACT_MISSILE {DMG} {STR}}
+      [/object]
+    [/case]
+    [case]
+      value=5
+      [object]
+        silent=yes
+        duration=forever
+        {SXC_ENEMY_WEAPON_PIERCE_MISSILE {DMG} {STR}}
+      [/object]
+    [/case]
+  [/switch]
 #enddef
 
 #define SXC_ENEMY_UPGRADE
   [event]
     name=recruit
     first_time_only=no
-    [store_unit]
+    [filter]
+      [filter_side]
+        team_name=Enemies
+      [/filter_side]
+    [/filter]
+    [modify_unit]
       [filter]
         x,y=$x1,$y1
-        [filter_side]
-          team_name=Enemies
-        [/filter_side]
       [/filter]
-      variable=creep
-    [/store_unit]
-    {VARIABLE creep_attacks_melee 0}
-    {VARIABLE creep_attacks_ranged 0}
-    {FOREACH creep.attack i}
-      {VARIABLE_OP creep_attacks_$creep.attack[$i|].range| add 1}
-    {NEXT i}
-    {VARIABLE new_trait_i $creep.modifications.trait.length}
-    {VARIABLE new_trait "creep.modifications.trait[$new_trait_i].id"}
-    {VARIABLE $new_trait loyal}
-    {VARIABLE new_trait "creep.modifications.trait[$new_trait_i].name"}
-    {VARIABLE $new_trait (_ "loyal")}
-    {VARIABLE new_trait "creep.modifications.trait[$new_trait_i].female_name"}
-    {VARIABLE $new_trait (_ "female^loyal")}
-    {VARIABLE new_trait "creep.modifications.trait[$new_trait_i].description"}
-    {VARIABLE $new_trait  (_ "Zero upkeep")}
-    {VARIABLE new_trait  "creep.modifications.trait[$new_trait_i].effect[0].apply_to"}
-    {VARIABLE $new_trait loyal}
-    {VARIABLE creep.role "recruits"}
-    [unstore_unit]
-      variable=creep
-    [/unstore_unit]
+      {TRAIT_LOYAL}
+      role="recruits"
+    [/modify_unit]
     {VARIABLE tenth_brutal "$(floor($brutal| / 10))"}
     [switch]
       variable=tenth_brutal
@@ -6853,7 +6876,32 @@ $maptext|"
       [/else]
     [/switch]
     {CLEAR_VARIABLE tenth_brutal}
-    {SXC_ENEMY_UPGRADE_WEAPON $sxc_boost_damage_constant $sxc_boost_strikes_constant}
+    [if]
+      [have_unit]
+        x,y=$x1,$y1
+        [not]
+          [has_attack]
+            range=melee
+          [/has_attack]
+        [/not]
+      [/have_unit]
+      [then]
+        {SXC_ENEMY_ADD_MELEE_WEAPON $sxc_boost_damage_constant $sxc_boost_strikes_constant}
+      [/then]
+    [/if]
+    [if]
+      [have_unit]
+        x,y=$x1,$y1
+        [not]
+          [has_attack]
+            range=ranged
+          [/has_attack]
+        [/not]
+      [/have_unit]
+      [then]
+        {SXC_ENEMY_ADD_RANGED_WEAPON $sxc_boost_damage_constant $sxc_boost_strikes_constant}
+      [/then]
+    [/if]
     [object]
       # implicitly filters to x,y=$x1,$y1
       silent=yes
@@ -6900,8 +6948,6 @@ $maptext|"
     {CLEAR_VARIABLE sxc_boost_strikes_constant}
     {CLEAR_VARIABLE sxc_boost_strikes_percent}
     {CLEAR_VARIABLE sxc_boost_res}
-    {CLEAR_VARIABLE new_trait_i}
-    {CLEAR_VARIABLE new_trait}
     {CLEAR_VARIABLE creep}
     {CLEAR_VARIABLE creep_attacks_melee}
     {CLEAR_VARIABLE creep_attacks_ranged}


### PR DESCRIPTION
This is a balance-changing bugfix. All recruited creeps were given the loyal
trait, but it was added in a way that didn't set their upkeep to zero (at least
in Wesnoth 1.14). So there's a huge cash-drain on the AI sides that was only
noticed when testing this commit Fixing this will change the map balance, but
it will probably improve the game and also make it easier, with more creeps to
earn gold from.

Use the mainline macros for the fearless and loyal traits.

These two changes go together, because the [store_unit] for adding the loyal
trait was also the [store_unit] for checking whether the recruit had both melee
and ranged attacks.

If a creep doesn't have a melee or ranged weapon, then one is added. The old
code generated a random number to choose the weapon type, even if it wouldn't
be used. This probably doesn't matter, looking at a replay there seems to be
just one random seed for each recruit event, so the extra random calls don't
add network traffic.